### PR TITLE
Fixed unused factory processor to support aliases

### DIFF
--- a/lib/factory_trace/helpers/converter.rb
+++ b/lib/factory_trace/helpers/converter.rb
@@ -21,7 +21,8 @@ module FactoryTrace
         FactoryTrace::Structures::Factory.new(
           factory.name.to_s,
           factory.send(:parent).respond_to?(:name) ? factory.send(:parent).name.to_s : nil,
-          factory.defined_traits.map(&:name).map(&:to_s)
+          factory.defined_traits.map(&:name).map(&:to_s),
+          factory.instance_eval('@aliases').map(&:to_s)
         )
       end
     end

--- a/lib/factory_trace/helpers/converter.rb
+++ b/lib/factory_trace/helpers/converter.rb
@@ -22,7 +22,7 @@ module FactoryTrace
           factory.name.to_s,
           factory.send(:parent).respond_to?(:name) ? factory.send(:parent).name.to_s : nil,
           factory.defined_traits.map(&:name).map(&:to_s),
-          factory.instance_eval('@aliases').map(&:to_s)
+          (factory.names - [factory.name]).map(&:to_s)
         )
       end
     end

--- a/lib/factory_trace/preprocessors/extract_used.rb
+++ b/lib/factory_trace/preprocessors/extract_used.rb
@@ -9,8 +9,11 @@ module FactoryTrace
       def self.call(trace)
         collection = FactoryTrace::Structures::Collection.new
 
-        trace.each do |factory_name, trait_names|
-          collection.add(FactoryTrace::Structures::Factory.new(factory_name, nil, trait_names.to_a))
+        trace.each do |factory_name, factory_data|
+          traits = factory_data[:traits].to_a
+          alias_names = factory_data[:alias_names].to_a
+
+          collection.add(FactoryTrace::Structures::Factory.new(factory_name, nil, traits, alias_names))
         end
 
         collection

--- a/lib/factory_trace/processors/find_unused.rb
+++ b/lib/factory_trace/processors/find_unused.rb
@@ -103,8 +103,15 @@ module FactoryTrace
         hash = {}
 
         used.factories.each_value do |factory|
-          parent_name = defined.factories[factory.name].parent_name
+          defined_factory = defined.factories[factory.name]
 
+          unless defined_factory
+            defined_factory = defined.factories.select do |_, f|
+              f.alias_names.include? factory.name
+            end.values.first
+          end
+
+          parent_name = defined_factory.parent_name
           if parent_name
             hash[parent_name] ||= []
             hash[parent_name] << factory.name

--- a/lib/factory_trace/structures/factory.rb
+++ b/lib/factory_trace/structures/factory.rb
@@ -36,7 +36,7 @@ module FactoryTrace
       def ==(factory)
         return false unless factory.is_a?(FactoryTrace::Structures::Factory)
 
-        (name == factory.name || (alias_names & factory.alias_names).present?) &&
+        (name == factory.name || alias_names == factory.alias_names) &&
           parent_name == factory.parent_name &&
           trait_names == factory.trait_names
       end

--- a/lib/factory_trace/structures/factory.rb
+++ b/lib/factory_trace/structures/factory.rb
@@ -1,21 +1,23 @@
 module FactoryTrace
   module Structures
     class Factory
-      attr_reader :name, :parent_name, :trait_names
+      attr_reader :name, :parent_name, :trait_names, :alias_names
 
       # @param [String] name
       # @param [String, nil] parent_name
       # @param [Array<String>] trait_names
-      def initialize(name, parent_name, trait_names)
+      def initialize(name, parent_name, trait_names, alias_names = [])
         @name = name
         @parent_name = parent_name
         @trait_names = trait_names
+        @alias_names = alias_names
       end
 
       # @return [Hash<Symbol, String>]
       def to_h
         {
           name: name,
+          alias_names: alias_names,
           parent_name: parent_name,
           trait_names: trait_names
         }
@@ -34,7 +36,9 @@ module FactoryTrace
       def ==(factory)
         return false unless factory.is_a?(FactoryTrace::Structures::Factory)
 
-        name == factory.name && parent_name == factory.parent_name && trait_names == factory.trait_names
+        (name == factory.name || (alias_names & factory.alias_names).present?) &&
+          parent_name == factory.parent_name &&
+          trait_names == factory.trait_names
       end
     end
   end

--- a/lib/factory_trace/tracker.rb
+++ b/lib/factory_trace/tracker.rb
@@ -8,11 +8,13 @@ module FactoryTrace
 
     def track!
       ActiveSupport::Notifications.subscribe('factory_bot.run_factory') do |_name, _start, _finish, _id, payload|
-        name = payload[:name].to_s
+        name = payload[:factory].name.to_s
         traits = payload[:traits].map(&:to_s)
+        alias_names = payload[:factory].names.map(&:to_s) - [name]
 
-        storage[name] ||= Set.new
-        storage[name] |= traits
+        storage[name] ||= { traits: Set.new, alias_names: Set.new }
+        storage[name][:traits] |= traits
+        storage[name][:alias_names] |= alias_names
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,6 +6,14 @@ class Company
   attr_accessor :address
 end
 
+class Article
+  attr_accessor :title, :user
+end
+
+class Comment
+  attr_accessor :article, :user, :body
+end
+
 FactoryBot.define do
   factory :user do
     name { 'name' }
@@ -19,6 +27,19 @@ FactoryBot.define do
     trait :with_email do
       email { 'email' }
     end
+  end
+
+  factory :article, aliases: %i[post] do
+    user
+
+    title { 'title' }
+  end
+
+  factory :comment do
+    user
+    post
+
+    body { 'comment body' }
   end
 
   factory :company

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,7 @@
 class User
   attr_accessor :name, :phone, :email, :address
+
+  def save! ; end
 end
 
 class Company

--- a/spec/factory_trace/helpers/converter_spec.rb
+++ b/spec/factory_trace/helpers/converter_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe FactoryTrace::Helpers::Converter do
   describe '.trait' do
-
-
     context 'when has no owner' do
       subject { described_class.trait(trait) }
 
@@ -20,6 +18,28 @@ RSpec.describe FactoryTrace::Helpers::Converter do
 
       specify do
         expect(subject).to eq(FactoryTrace::Structures::Trait.new('with_phone', 'user'))
+      end
+    end
+  end
+
+  describe '.factory' do
+    context 'when has no aliases' do
+      subject { described_class.factory(factory) }
+
+      let(:factory) { find_factory('comment') }
+
+      specify do
+        expect(subject).to eq(FactoryTrace::Structures::Factory.new('user', nil, [], []))
+      end
+    end
+
+    context 'when has aliases' do
+      subject { described_class.factory(factory) }
+
+      let(:factory) { find_factory('article') }
+
+      specify do
+        expect(subject).to eq(FactoryTrace::Structures::Factory.new('article', nil, [], ['post']))
       end
     end
   end

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
         {
           'user' => FactoryTrace::Structures::Factory.new('user', nil, ['with_phone']),
           'admin' => FactoryTrace::Structures::Factory.new('admin', 'user', ['with_email']),
+          'article' => FactoryTrace::Structures::Factory.new('article', nil, [], ['post']),
+          'comment' => FactoryTrace::Structures::Factory.new('comment', nil, []),
           'company' => FactoryTrace::Structures::Factory.new('company', nil, [])
         },
         {

--- a/spec/factory_trace/preprocessors/extract_used_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_used_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe FactoryTrace::Preprocessors::ExtractUsed do
   describe '.call' do
-    subject { described_class.call({'admin' => Set.new(['with_address'])}) }
+    subject { described_class.call({'admin' => { traits: Set.new(['with_address']), alias_names: Set.new }}) }
 
     specify do
       collection = FactoryTrace::Structures::Collection.new(

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe FactoryTrace::Structures::Factory do
+  describe '#==' do
+    let(:user_factory) { find_factory('user') }
+    let(:comment_factory) { find_factory('comment') }
+    let(:article_factory) { find_factory('article') }
+
+    it { expect(user_factory == user_factory).to be_truthy }
+    it { expect(comment_factory == comment_factory).to be_truthy }
+    it { expect(article_factory == article_factory).to be_truthy }
+
+    it { expect(user_factory == comment_factory).to be_falsey }
+    it { expect(user_factory == article_factory).to be_falsey }
+    it { expect(comment_factory == article_factory).to be_falsey }
+  end
+end

--- a/spec/factory_trace/tracker_spec.rb
+++ b/spec/factory_trace/tracker_spec.rb
@@ -7,19 +7,28 @@ RSpec.describe FactoryTrace::Tracker do
     it 'collects used factories without traits' do
       build(:user)
 
-      expect(tracker.storage).to eq('user' => Set.new)
+      expect(tracker.storage).to eq('user' => { traits: Set.new, alias_names: Set.new })
     end
 
     it 'collects used factories with traits' do
       build(:user, :with_phone)
 
-      expect(tracker.storage).to eq('user' => Set.new(['with_phone']))
+      expect(tracker.storage).to eq('user' => { traits: Set.new(['with_phone']), alias_names: Set.new })
     end
 
     it 'collects used factories with global traits' do
       build(:user, :with_address)
 
-      expect(tracker.storage).to eq('user' => Set.new(['with_address']))
+      expect(tracker.storage).to eq('user' => { traits: Set.new(['with_address']), alias_names: Set.new })
+    end
+
+    it 'collects used factories with alias' do
+      build(:post)
+
+      expect(tracker.storage).to eq(
+        'article' => { traits: Set.new, alias_names: Set.new(['post']) },
+        'user' => { traits: Set.new, alias_names: Set.new }
+      )
     end
 
     it 'collects all used factories' do
@@ -27,7 +36,11 @@ RSpec.describe FactoryTrace::Tracker do
       build(:admin, :with_phone, :with_email)
       build(:company, :with_address)
 
-      expect(tracker.storage).to eq('user' => Set.new, 'admin' => Set.new(['with_phone', 'with_email']), 'company' => Set.new(['with_address']))
+      expect(tracker.storage).to eq(
+        'user' => { traits: Set.new, alias_names: Set.new },
+        'admin' => { traits: Set.new(['with_phone', 'with_email']), alias_names: Set.new },
+        'company' => { traits: Set.new(['with_address']), alias_names: Set.new }
+      )
     end
   end
 end

--- a/spec/factory_trace/writers/trace_writer_spec.rb
+++ b/spec/factory_trace/writers/trace_writer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FactoryTrace::Writers::TraceWriter do
     let(:defined) do
       FactoryTrace::Structures::Collection.new(
         {
-          'user' => FactoryTrace::Structures::Factory.new('user', nil, ['with_phone'])
+          'user' => FactoryTrace::Structures::Factory.new('user', nil, ['with_phone'], ['author'])
         },
         {
           'with_address' => FactoryTrace::Structures::Trait.new('with_address', nil)
@@ -28,7 +28,7 @@ RSpec.describe FactoryTrace::Writers::TraceWriter do
             {
               "name": "user",
               "alias_names": [
-
+                "author"
               ],
               "parent_name": null,
               "trait_names": [

--- a/spec/factory_trace/writers/trace_writer_spec.rb
+++ b/spec/factory_trace/writers/trace_writer_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe FactoryTrace::Writers::TraceWriter do
           "factories": [
             {
               "name": "user",
+              "alias_names": [
+
+              ],
               "parent_name": null,
               "trait_names": [
                 "with_phone"


### PR DESCRIPTION
Unused factory processor fails on factory aliases

Factory example to reproduce:

```
FactoryBot.define do
  factory :user, aliases: %i[author] do
    email                 { Faker::Internet.email }
  end
end

FactoryBot.define do
  factory :post do
    author

    title { 'Title' }
  end
end
```

got:

```
NoMethodError:
  undefined method `parent_name' for nil:NilClass
```