### PR TITLE
Set up `RuboCop` based on `Standard`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,23 @@ jobs:
       - store_test_results:
           path: test_results
 
+  rubocop:
+    executor:
+      name: ruby
+      tag: "2.5"
+    steps:
+      - attach_workspace:
+          at: ~/factory_trace
+      - run:
+          name: Use gemfiles/rubocop.gemfile as the Gemfile
+          command: bundle config --global gemfile gemfiles/rubocop.gemfile
+      - run:
+          name: Install the gems specified by the Gemfile
+          command: bundle install
+      - run:
+          name: Lint Ruby code with RuboCop
+          command: bundle exec rubocop --parallel
+
 workflows:
   version: 2
   default: &default
@@ -85,6 +102,9 @@ workflows:
                 "gemfiles/fb_6_2.gemfile"
               ]
           name: build-ruby-<< matrix.ruby-version >>/fb-<< matrix.gemfile >>
+      - rubocop:
+          requires:
+            - checkout
 
   nightly:
     triggers:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,8 @@ AllCops:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+
+############### RSpec ###############
+
+RSpec/ExampleLength:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ inherit_gem:
 
 AllCops:
   Exclude:
-    - "bin/*"
     - "rails-rspec-example/**/*"
   TargetRubyVersion: 2.5
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
+  NewCops: enable
   Exclude:
     - "rails-rspec-example/**/*"
   TargetRubyVersion: 2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+require:
+  - standard/cop/block_single_line_braces
+  - rubocop-rake
+  - rubocop-rspec
+
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  Exclude:
+    - "bin/*"
+    - "rails-rspec-example/**/*"
+  TargetRubyVersion: 2.5
+
+############### Style ###############
+
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,7 @@ Style/FrozenStringLiteralComment:
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/FilePath:
+  Exclude:
+    - spec/factory_trace/integration_tests/empty_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
-local_gemfile = 'Gemfile.local'
+local_gemfile = "Gemfile.local"
 
 if File.exist?(local_gemfile)
   eval(File.read(local_gemfile))
 else
-  gem 'factory_bot', '~> 6.0'
+  gem "factory_bot", "~> 6.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ if File.exist?(local_gemfile)
 else
   gem "factory_bot", "~> 6.0"
 end
+
+eval_gemfile("gemfiles/rubocop.gemfile")

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 local_gemfile = "Gemfile.local"
 
 if File.exist?(local_gemfile)
-  eval(File.read(local_gemfile))
+  eval_gemfile(local_gemfile)
 else
   gem "factory_bot", "~> 6.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,12 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  desc "Lint Ruby files with RuboCop"
+  task(:rubocop)
+end
+
+task default: [:spec, :rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/exe/factory_trace
+++ b/exe/factory_trace
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 $LOAD_PATH.unshift("#{__dir__}/../lib")
 require "factory_trace"

--- a/exe/factory_trace
+++ b/exe/factory_trace
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift("#{__dir__}/../lib")
-require 'factory_trace'
+require "factory_trace"
 
 fail "You should pass at least one file with traced information.\nYou can generate it using only_trace mode." if ARGV.empty?
 

--- a/factory_trace.gemspec
+++ b/factory_trace.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "factory_trace/version"

--- a/factory_trace.gemspec
+++ b/factory_trace.gemspec
@@ -1,26 +1,26 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'factory_trace/version'
+require "factory_trace/version"
 
 Gem::Specification.new do |spec|
-  spec.name = 'factory_trace'
+  spec.name = "factory_trace"
   spec.version = FactoryTrace::VERSION
-  spec.authors = ['djezzzl']
-  spec.email = ['lawliet.djez@gmail.com']
+  spec.authors = ["djezzzl"]
+  spec.email = ["lawliet.djez@gmail.com"]
 
-  spec.summary = 'Provide an easy way to maintain factories and traits from FactoryBot'
-  spec.homepage = 'https://github.com/djezzzl/factory_trace'
-  spec.license = 'MIT'
+  spec.summary = "Provide an easy way to maintain factories and traits from FactoryBot"
+  spec.homepage = "https://github.com/djezzzl/factory_trace"
+  spec.license = "MIT"
 
-  spec.files = Dir['lib/**/*']
-  spec.bindir = 'exe'
-  spec.executables = ['factory_trace']
-  spec.require_paths = ['lib']
+  spec.files = Dir["lib/**/*"]
+  spec.bindir = "exe"
+  spec.executables = ["factory_trace"]
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'factory_bot', '>= 4.0'
+  spec.add_dependency "factory_bot", ">= 4.0"
 
-  spec.add_development_dependency 'bundler', '>= 1.17.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
+  spec.add_development_dependency "bundler", ">= 1.17.0"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec_junit_formatter", "~> 0.4"
 end

--- a/factory_trace.gemspec
+++ b/factory_trace.gemspec
@@ -3,16 +3,16 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'factory_trace/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'factory_trace'
-  spec.version       = FactoryTrace::VERSION
-  spec.authors       = ['djezzzl']
-  spec.email         = ['lawliet.djez@gmail.com']
+  spec.name = 'factory_trace'
+  spec.version = FactoryTrace::VERSION
+  spec.authors = ['djezzzl']
+  spec.email = ['lawliet.djez@gmail.com']
 
-  spec.summary       = 'Provide an easy way to maintain factories and traits from FactoryBot'
-  spec.homepage      = 'https://github.com/djezzzl/factory_trace'
-  spec.license       = 'MIT'
+  spec.summary = 'Provide an easy way to maintain factories and traits from FactoryBot'
+  spec.homepage = 'https://github.com/djezzzl/factory_trace'
+  spec.license = 'MIT'
 
-  spec.files         = Dir['lib/**/*']
+  spec.files = Dir['lib/**/*']
   spec.bindir = 'exe'
   spec.executables = ['factory_trace']
   spec.require_paths = ['lib']

--- a/gemfiles/fb_4_10.gemfile
+++ b/gemfiles/fb_4_10.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 4.10.0'
+gem "factory_bot", "~> 4.10.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_4_10.gemfile
+++ b/gemfiles/fb_4_10.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 4.10.0"

--- a/gemfiles/fb_4_11.gemfile
+++ b/gemfiles/fb_4_11.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 4.11.0'
+gem "factory_bot", "~> 4.11.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_4_11.gemfile
+++ b/gemfiles/fb_4_11.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 4.11.0"

--- a/gemfiles/fb_5_0.gemfile
+++ b/gemfiles/fb_5_0.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 5.0.0"

--- a/gemfiles/fb_5_0.gemfile
+++ b/gemfiles/fb_5_0.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 5.0.0'
+gem "factory_bot", "~> 5.0.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_5_1.gemfile
+++ b/gemfiles/fb_5_1.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 5.1.0"

--- a/gemfiles/fb_5_1.gemfile
+++ b/gemfiles/fb_5_1.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 5.1.0'
+gem "factory_bot", "~> 5.1.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_5_2.gemfile
+++ b/gemfiles/fb_5_2.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 5.2.0"

--- a/gemfiles/fb_5_2.gemfile
+++ b/gemfiles/fb_5_2.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 5.2.0'
+gem "factory_bot", "~> 5.2.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_6_0.gemfile
+++ b/gemfiles/fb_6_0.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 6.0.0'
+gem "factory_bot", "~> 6.0.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_6_0.gemfile
+++ b/gemfiles/fb_6_0.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 6.0.0"

--- a/gemfiles/fb_6_1.gemfile
+++ b/gemfiles/fb_6_1.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 6.1.0'
+gem "factory_bot", "~> 6.1.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_6_1.gemfile
+++ b/gemfiles/fb_6_1.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 6.1.0"

--- a/gemfiles/fb_6_2.gemfile
+++ b/gemfiles/fb_6_2.gemfile
@@ -1,5 +1,5 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'factory_bot', '~> 6.2.0'
+gem "factory_bot", "~> 6.2.0"
 
-gemspec path: '../'
+gemspec path: "../"

--- a/gemfiles/fb_6_2.gemfile
+++ b/gemfiles/fb_6_2.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 6.2.0"

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org" do
   gem "standard", "~> 1.3"
   gem "rubocop-rake", "~> 0.6"

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org" do
+  gem "standard", "~> 1.3"
+  gem "rubocop-rake", "~> 0.6"
+  gem "rubocop-rspec", "~> 2.5"
+end

--- a/lib/factory_trace.rb
+++ b/lib/factory_trace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # External dependencies
 require "factory_bot"
 require "json"

--- a/lib/factory_trace.rb
+++ b/lib/factory_trace.rb
@@ -1,38 +1,38 @@
 # External dependencies
-require 'factory_bot'
-require 'json'
-require 'set'
-require 'pathname'
+require "factory_bot"
+require "json"
+require "set"
+require "pathname"
 # Library
-require 'factory_trace/configuration'
-require 'factory_trace/version'
-require 'factory_trace/helpers/converter'
-require 'factory_trace/helpers/statusable'
-require 'factory_trace/helpers/caller'
-require 'factory_trace/tracker'
+require "factory_trace/configuration"
+require "factory_trace/version"
+require "factory_trace/helpers/converter"
+require "factory_trace/helpers/statusable"
+require "factory_trace/helpers/caller"
+require "factory_trace/tracker"
 
-require 'factory_trace/structures/factory'
-require 'factory_trace/structures/trait'
-require 'factory_trace/structures/collection'
+require "factory_trace/structures/factory"
+require "factory_trace/structures/trait"
+require "factory_trace/structures/collection"
 
-require 'factory_trace/preprocessors/extract_defined'
-require 'factory_trace/preprocessors/extract_used'
+require "factory_trace/preprocessors/extract_defined"
+require "factory_trace/preprocessors/extract_used"
 
-require 'factory_trace/processors/find_unused'
+require "factory_trace/processors/find_unused"
 
-require 'factory_trace/readers/trace_reader'
-require 'factory_trace/writers/writer'
-require 'factory_trace/writers/report_writer'
-require 'factory_trace/writers/trace_writer'
+require "factory_trace/readers/trace_reader"
+require "factory_trace/writers/writer"
+require "factory_trace/writers/report_writer"
+require "factory_trace/writers/trace_writer"
 
-require 'factory_trace/monkey_patches/monkey_patches'
-require 'factory_trace/monkey_patches/factory'
-require 'factory_trace/monkey_patches/trait'
-require 'factory_trace/monkey_patches/definition_proxy'
-require 'factory_trace/monkey_patches/dsl'
+require "factory_trace/monkey_patches/monkey_patches"
+require "factory_trace/monkey_patches/factory"
+require "factory_trace/monkey_patches/trait"
+require "factory_trace/monkey_patches/definition_proxy"
+require "factory_trace/monkey_patches/dsl"
 
 # Integrations
-require 'integrations/rspec' if defined?(RSpec::Core)
+require "integrations/rspec" if defined?(RSpec::Core)
 
 module FactoryTrace
   class << self

--- a/lib/factory_trace/configuration.rb
+++ b/lib/factory_trace/configuration.rb
@@ -15,7 +15,7 @@ module FactoryTrace
     end
 
     def out
-      return STDOUT unless path
+      return $stdout unless path
 
       File.open(path, "w")
     end

--- a/lib/factory_trace/configuration.rb
+++ b/lib/factory_trace/configuration.rb
@@ -27,7 +27,7 @@ module FactoryTrace
     private
 
     def extract_mode(value)
-      matcher = value && value.match(/full|trace_only/)
+      matcher = value&.match(/full|trace_only/)
       matcher && matcher[0].to_sym
     end
   end

--- a/lib/factory_trace/configuration.rb
+++ b/lib/factory_trace/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   class Configuration
     attr_accessor :path, :enabled, :color, :mode, :trace_definition

--- a/lib/factory_trace/configuration.rb
+++ b/lib/factory_trace/configuration.rb
@@ -3,10 +3,10 @@ module FactoryTrace
     attr_accessor :path, :enabled, :color, :mode, :trace_definition
 
     def initialize
-      @enabled = ENV.key?('FB_TRACE') || ENV.key?('FB_TRACE_FILE')
-      @path = ENV['FB_TRACE_FILE']
+      @enabled = ENV.key?("FB_TRACE") || ENV.key?("FB_TRACE_FILE")
+      @path = ENV["FB_TRACE_FILE"]
       @color = path.nil?
-      @mode = extract_mode(ENV['FB_TRACE']) || :full
+      @mode = extract_mode(ENV["FB_TRACE"]) || :full
       @trace_definition = true
     end
 
@@ -17,7 +17,7 @@ module FactoryTrace
     def out
       return STDOUT unless path
 
-      File.open(path, 'w')
+      File.open(path, "w")
     end
 
     def mode?(*args)

--- a/lib/factory_trace/helpers/caller.rb
+++ b/lib/factory_trace/helpers/caller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Helpers
     module Caller

--- a/lib/factory_trace/helpers/caller.rb
+++ b/lib/factory_trace/helpers/caller.rb
@@ -7,7 +7,7 @@ module FactoryTrace
 
       # @return [String] file and line where the original method was called
       def location
-        location = caller_locations[1]
+        location = caller_locations(2..2).first
 
         base = Pathname.new(Dir.pwd)
         method = Pathname.new(location.path)

--- a/lib/factory_trace/helpers/converter.rb
+++ b/lib/factory_trace/helpers/converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Helpers
     module Converter

--- a/lib/factory_trace/helpers/converter.rb
+++ b/lib/factory_trace/helpers/converter.rb
@@ -34,7 +34,7 @@ module FactoryTrace
       # @return [Array<String>]
       def extract_declarations(structure)
         (structure.definition.declarations.grep(FactoryBot::Declaration::Implicit).map(&:name).map(&:to_s) +
-          structure.definition.instance_variable_get(:'@base_traits').map(&:to_s)).uniq
+          structure.definition.instance_variable_get(:@base_traits).map(&:to_s)).uniq
       end
     end
   end

--- a/lib/factory_trace/helpers/statusable.rb
+++ b/lib/factory_trace/helpers/statusable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Helpers
     module Statusable

--- a/lib/factory_trace/monkey_patches/definition_proxy.rb
+++ b/lib/factory_trace/monkey_patches/definition_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module MonkeyPatches
     module DefinitionProxy

--- a/lib/factory_trace/monkey_patches/dsl.rb
+++ b/lib/factory_trace/monkey_patches/dsl.rb
@@ -8,7 +8,7 @@ module FactoryTrace
           caller_location = options.delete(:caller_location) || Helpers::Caller.location
           factory = FactoryBot::Factory.new(name, caller_location, options)
           proxy = FactoryBot::DefinitionProxy.new(factory.definition)
-          proxy.instance_eval(&block) if block_given?
+          proxy.instance_eval(&block) if block
 
           REGISTER.register_factory(factory)
 

--- a/lib/factory_trace/monkey_patches/dsl.rb
+++ b/lib/factory_trace/monkey_patches/dsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module MonkeyPatches
     module Default

--- a/lib/factory_trace/monkey_patches/factory.rb
+++ b/lib/factory_trace/monkey_patches/factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module MonkeyPatches
     module Factory

--- a/lib/factory_trace/monkey_patches/monkey_patches.rb
+++ b/lib/factory_trace/monkey_patches/monkey_patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module MonkeyPatches
     REGISTER = FactoryBot::VERSION >= "5.1.0" ? FactoryBot::Internal : FactoryBot

--- a/lib/factory_trace/monkey_patches/monkey_patches.rb
+++ b/lib/factory_trace/monkey_patches/monkey_patches.rb
@@ -1,5 +1,5 @@
 module FactoryTrace
   module MonkeyPatches
-    REGISTER = FactoryBot::VERSION >= '5.1.0' ? FactoryBot::Internal : FactoryBot
+    REGISTER = FactoryBot::VERSION >= "5.1.0" ? FactoryBot::Internal : FactoryBot
   end
 end

--- a/lib/factory_trace/monkey_patches/trait.rb
+++ b/lib/factory_trace/monkey_patches/trait.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module MonkeyPatches
     module Trait

--- a/lib/factory_trace/preprocessors/extract_defined.rb
+++ b/lib/factory_trace/preprocessors/extract_defined.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Preprocessors
     class ExtractDefined

--- a/lib/factory_trace/preprocessors/extract_used.rb
+++ b/lib/factory_trace/preprocessors/extract_used.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Preprocessors
     class ExtractUsed

--- a/lib/factory_trace/processors/find_unused.rb
+++ b/lib/factory_trace/processors/find_unused.rb
@@ -3,36 +3,36 @@
 module FactoryTrace
   module Processors
     class FindUnused
-      # Finds unused factories and traits
-      #
-      # @param [FactoryTrace::Structures::Collection] defined
-      # @param [FactoryTrace::Structures::Collection] used
-      #
-      # @return [Array<Hash>]
-      def self.call(defined, used)
-        mark_as_used(defined, used)
-
-        output = []
-
-        defined.factories.each do |factory|
-          output << append_definition_path({code: :unused, factory_names: factory.names}, factory) unless factory.status
-
-          factory.traits.each do |trait|
-            output << append_definition_path({code: :unused, factory_names: factory.names, trait_name: trait.name}, trait) unless trait.status
-          end
-        end
-
-        defined.traits.each do |trait|
-          output << append_definition_path({code: :unused, trait_name: trait.name}, trait) unless trait.status
-        end
-
-        output.unshift(code: :unused, value: output.size)
-        output.unshift(code: :used, value: defined.total - (output.size - 1))
-
-        output
-      end
-
       class << self
+        # Finds unused factories and traits
+        #
+        # @param [FactoryTrace::Structures::Collection] defined
+        # @param [FactoryTrace::Structures::Collection] used
+        #
+        # @return [Array<Hash>]
+        def call(defined, used)
+          mark_as_used(defined, used)
+
+          output = []
+
+          defined.factories.each do |factory|
+            output << append_definition_path({code: :unused, factory_names: factory.names}, factory) unless factory.status
+
+            factory.traits.each do |trait|
+              output << append_definition_path({code: :unused, factory_names: factory.names, trait_name: trait.name}, trait) unless trait.status
+            end
+          end
+
+          defined.traits.each do |trait|
+            output << append_definition_path({code: :unused, trait_name: trait.name}, trait) unless trait.status
+          end
+
+          output.unshift(code: :unused, value: output.size)
+          output.unshift(code: :used, value: defined.total - (output.size - 1))
+
+          output
+        end
+
         private
 
         # @param [FactoryTrace::Structures::Collection] defined

--- a/lib/factory_trace/processors/find_unused.rb
+++ b/lib/factory_trace/processors/find_unused.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Processors
     class FindUnused

--- a/lib/factory_trace/processors/find_unused.rb
+++ b/lib/factory_trace/processors/find_unused.rb
@@ -32,87 +32,89 @@ module FactoryTrace
         output
       end
 
-      private
+      class << self
+        private
 
-      # @param [FactoryTrace::Structures::Collection] defined
-      # @param [FactoryTrace::Structures::Collection] used
-      def self.mark_as_used(defined, used)
-        used.factories.each do |used_factory|
-          defined_factory = defined.find_factory_by_names(used_factory.names)
-          mark_factory(defined_factory, defined, status: :used)
+        # @param [FactoryTrace::Structures::Collection] defined
+        # @param [FactoryTrace::Structures::Collection] used
+        def mark_as_used(defined, used)
+          used.factories.each do |used_factory|
+            defined_factory = defined.find_factory_by_names(used_factory.names)
+            mark_factory(defined_factory, defined, status: :used)
 
-          used_factory.traits.each do |used_trait|
-            trait_owner, defined_trait = defined_trait_by_name(defined, used_factory, used_trait.name)
-            mark_trait(defined_trait, trait_owner, defined, status: :used)
-          end
-        end
-      end
-
-      # @param [FactoryTrace::Structures::Collection] defined
-      # @param [FactoryTrace::Structures::Factory|nil] factory
-      # @param [String] trait_name
-      #
-      # @return [Array<Object>]
-      def self.defined_trait_by_name(defined, factory, trait_name)
-        if factory
-          possible_owner = defined.find_factory_by_names(factory.names)
-
-          while possible_owner
-            if (trait = possible_owner.traits.find { |t| t.name == trait_name })
-              return [possible_owner, trait]
+            used_factory.traits.each do |used_trait|
+              trait_owner, defined_trait = defined_trait_by_name(defined, used_factory, used_trait.name)
+              mark_trait(defined_trait, trait_owner, defined, status: :used)
             end
-            possible_owner = defined.find_factory_by_names([possible_owner.parent_name])
           end
         end
 
-        [nil, defined.find_trait_by_name(trait_name)]
-      end
+        # @param [FactoryTrace::Structures::Collection] defined
+        # @param [FactoryTrace::Structures::Factory|nil] factory
+        # @param [String] trait_name
+        #
+        # @return [Array<Object>]
+        def defined_trait_by_name(defined, factory, trait_name)
+          if factory
+            possible_owner = defined.find_factory_by_names(factory.names)
 
-      # @param [FactoryTrace::Structures::Factory] factory
-      # @param [FactoryTrace::Structures::Collection] collection
-      # @param [Symbol] status
-      def self.mark_factory(factory, collection, status:)
-        return if factory.has_prioritized_status?(status)
+            while possible_owner
+              if (trait = possible_owner.traits.find { |t| t.name == trait_name })
+                return [possible_owner, trait]
+              end
+              possible_owner = defined.find_factory_by_names([possible_owner.parent_name])
+            end
+          end
 
-        factory.status = status
-        if (parent = collection.find_factory_by_names([factory.parent_name]))
-          mark_factory(parent, collection, status: :indirectly_used)
+          [nil, defined.find_trait_by_name(trait_name)]
         end
-        mark_declarations(factory.declaration_names, factory, collection, status: :indirectly_used)
-      end
 
-      # @param [FactoryTrace::Structures::Trait] trait
-      # @param [FactoryTrace::Structures::Factory|nil] factory which trait belongs to
-      # @param [FactoryTrace::Structures::Collection] collection
-      # @param [Symbol] status
-      def self.mark_trait(trait, factory, collection, status:)
-        return if trait.has_prioritized_status?(status)
+        # @param [FactoryTrace::Structures::Factory] factory
+        # @param [FactoryTrace::Structures::Collection] collection
+        # @param [Symbol] status
+        def mark_factory(factory, collection, status:)
+          return if factory.has_prioritized_status?(status)
 
-        trait.status = status
-        mark_declarations(trait.declaration_names, factory, collection, status: :indirectly_used)
-      end
-
-      # @param [Array<String>] declaration_names
-      # @param [FactoryTrace::Structures::Factory|nil] factory
-      # @param [FactoryTrace::Structures::Collection] collection
-      # @param [Symbol] status
-      def self.mark_declarations(declaration_names, factory, collection, status:)
-        declaration_names.each do |declaration_name|
-          declaration_factory = collection.find_factory_by_names([declaration_name])
-          next mark_factory(declaration_factory, collection, status: status) if declaration_factory
-
-          declaration_factory, declaration_trait = defined_trait_by_name(collection, factory, declaration_name)
-          mark_trait(declaration_trait, declaration_factory, collection, status: status) if declaration_trait
+          factory.status = status
+          if (parent = collection.find_factory_by_names([factory.parent_name]))
+            mark_factory(parent, collection, status: :indirectly_used)
+          end
+          mark_declarations(factory.declaration_names, factory, collection, status: :indirectly_used)
         end
-      end
 
-      # @param [Hash]
-      # @param [FactoryTrace::Structures::Factory|FactoryTrace::Structures::Trait]
-      #
-      # @return [Hash]
-      def self.append_definition_path(hash, object)
-        hash[:definition_path] = object.definition_path if object.definition_path
-        hash
+        # @param [FactoryTrace::Structures::Trait] trait
+        # @param [FactoryTrace::Structures::Factory|nil] factory which trait belongs to
+        # @param [FactoryTrace::Structures::Collection] collection
+        # @param [Symbol] status
+        def mark_trait(trait, factory, collection, status:)
+          return if trait.has_prioritized_status?(status)
+
+          trait.status = status
+          mark_declarations(trait.declaration_names, factory, collection, status: :indirectly_used)
+        end
+
+        # @param [Array<String>] declaration_names
+        # @param [FactoryTrace::Structures::Factory|nil] factory
+        # @param [FactoryTrace::Structures::Collection] collection
+        # @param [Symbol] status
+        def mark_declarations(declaration_names, factory, collection, status:)
+          declaration_names.each do |declaration_name|
+            declaration_factory = collection.find_factory_by_names([declaration_name])
+            next mark_factory(declaration_factory, collection, status: status) if declaration_factory
+
+            declaration_factory, declaration_trait = defined_trait_by_name(collection, factory, declaration_name)
+            mark_trait(declaration_trait, declaration_factory, collection, status: status) if declaration_trait
+          end
+        end
+
+        # @param [Hash]
+        # @param [FactoryTrace::Structures::Factory|FactoryTrace::Structures::Trait]
+        #
+        # @return [Hash]
+        def append_definition_path(hash, object)
+          hash[:definition_path] = object.definition_path if object.definition_path
+          hash
+        end
       end
     end
   end

--- a/lib/factory_trace/processors/find_unused.rb
+++ b/lib/factory_trace/processors/find_unused.rb
@@ -63,7 +63,6 @@ module FactoryTrace
           end
         end
 
-
         [nil, defined.find_trait_by_name(trait_name)]
       end
 

--- a/lib/factory_trace/readers/trace_reader.rb
+++ b/lib/factory_trace/readers/trace_reader.rb
@@ -10,7 +10,7 @@ module FactoryTrace
         result = {defined: FactoryTrace::Structures::Collection.new, used: FactoryTrace::Structures::Collection.new}
 
         file_names.each do |file_name|
-          File.open(file_name, 'r') do |file|
+          File.open(file_name, "r") do |file|
             data = new(file, configuration: configuration).read
 
             [:defined, :used].each do |key|
@@ -34,35 +34,35 @@ module FactoryTrace
         hash = JSON.parse(io.read)
 
         {
-          defined: parse_collection(hash['defined']),
-          used: parse_collection(hash['used'])
+          defined: parse_collection(hash["defined"]),
+          used: parse_collection(hash["used"])
         }
       end
 
       private
 
       def parse_trait(hash)
-        FactoryTrace::Structures::Trait.new(hash['name'], declaration_names: hash['declaration_names'], definition_path: hash['definition_path'])
+        FactoryTrace::Structures::Trait.new(hash["name"], declaration_names: hash["declaration_names"], definition_path: hash["definition_path"])
       end
 
       def parse_factory(hash)
         FactoryTrace::Structures::Factory.new(
-          hash['names'],
-          hash['traits'].map(&method(:parse_trait)),
-          parent_name: hash['parent_name'],
-          declaration_names: hash['declaration_names'],
-          definition_path: hash['definition_path']
+          hash["names"],
+          hash["traits"].map(&method(:parse_trait)),
+          parent_name: hash["parent_name"],
+          declaration_names: hash["declaration_names"],
+          definition_path: hash["definition_path"]
         )
       end
 
       def parse_collection(hash)
         collection = FactoryTrace::Structures::Collection.new
 
-        hash['factories'].each do |h|
+        hash["factories"].each do |h|
           collection.add(parse_factory(h))
         end
 
-        hash['traits'].each do |h|
+        hash["traits"].each do |h|
           collection.add(parse_trait(h))
         end
 

--- a/lib/factory_trace/readers/trace_reader.rb
+++ b/lib/factory_trace/readers/trace_reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Readers
     class TraceReader

--- a/lib/factory_trace/structures/collection.rb
+++ b/lib/factory_trace/structures/collection.rb
@@ -71,10 +71,10 @@ module FactoryTrace
       end
 
       # @return [Boolean]
-      def ==(collection)
-        return false unless collection.is_a?(FactoryTrace::Structures::Collection)
+      def ==(other)
+        return false unless other.is_a?(FactoryTrace::Structures::Collection)
 
-        factories == collection.factories && traits == collection.traits
+        factories == other.factories && traits == other.traits
       end
     end
   end

--- a/lib/factory_trace/structures/collection.rb
+++ b/lib/factory_trace/structures/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Structures
     class Collection

--- a/lib/factory_trace/structures/factory.rb
+++ b/lib/factory_trace/structures/factory.rb
@@ -41,14 +41,14 @@ module FactoryTrace
       end
 
       # @return [Boolean]
-      def ==(factory)
-        return false unless factory.is_a?(FactoryTrace::Structures::Factory)
+      def ==(other)
+        return false unless other.is_a?(FactoryTrace::Structures::Factory)
 
-        names == factory.names &&
-          traits == factory.traits &&
-          parent_name == factory.parent_name &&
-          declaration_names == factory.declaration_names &&
-          definition_path == factory.definition_path
+        names == other.names &&
+          traits == other.traits &&
+          parent_name == other.parent_name &&
+          declaration_names == other.declaration_names &&
+          definition_path == other.definition_path
       end
     end
   end

--- a/lib/factory_trace/structures/factory.rb
+++ b/lib/factory_trace/structures/factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Structures
     class Factory

--- a/lib/factory_trace/structures/trait.rb
+++ b/lib/factory_trace/structures/trait.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Structures
     class Trait

--- a/lib/factory_trace/structures/trait.rb
+++ b/lib/factory_trace/structures/trait.rb
@@ -26,10 +26,10 @@ module FactoryTrace
       end
 
       # @return [Boolean]
-      def ==(trait)
-        return false unless trait.is_a?(FactoryTrace::Structures::Trait)
+      def ==(other)
+        return false unless other.is_a?(FactoryTrace::Structures::Trait)
 
-        name == trait.name && declaration_names == trait.declaration_names && definition_path == trait.definition_path
+        name == other.name && declaration_names == other.declaration_names && definition_path == other.definition_path
       end
     end
   end

--- a/lib/factory_trace/tracker.rb
+++ b/lib/factory_trace/tracker.rb
@@ -7,7 +7,7 @@ module FactoryTrace
     end
 
     def track!
-      ActiveSupport::Notifications.subscribe('factory_bot.run_factory') do |_name, _start, _finish, _id, payload|
+      ActiveSupport::Notifications.subscribe("factory_bot.run_factory") do |_name, _start, _finish, _id, payload|
         name = payload[:name].to_s
         traits = payload[:traits].map(&:to_s)
 

--- a/lib/factory_trace/tracker.rb
+++ b/lib/factory_trace/tracker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   class Tracker
     attr_reader :storage

--- a/lib/factory_trace/version.rb
+++ b/lib/factory_trace/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   VERSION = "0.4.1"
 end

--- a/lib/factory_trace/version.rb
+++ b/lib/factory_trace/version.rb
@@ -1,3 +1,3 @@
 module FactoryTrace
-  VERSION = '0.4.1'
+  VERSION = "0.4.1"
 end

--- a/lib/factory_trace/writers/report_writer.rb
+++ b/lib/factory_trace/writers/report_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Writers
     class ReportWriter < Writer

--- a/lib/factory_trace/writers/report_writer.rb
+++ b/lib/factory_trace/writers/report_writer.rb
@@ -9,8 +9,8 @@ module FactoryTrace
       }.freeze
 
       CODES = {
-        used: 'used',
-        unused: 'unused',
+        used: "used",
+        unused: "unused",
       }.freeze
 
       # @param [Array<Hash>] results
@@ -57,7 +57,7 @@ module FactoryTrace
       end
 
       def list(elements, color: :blue)
-        elements.map { |element| colorize(color, element) }.join(', ')
+        elements.map { |element| colorize(color, element) }.join(", ")
       end
     end
   end

--- a/lib/factory_trace/writers/report_writer.rb
+++ b/lib/factory_trace/writers/report_writer.rb
@@ -27,12 +27,11 @@ module FactoryTrace
       # @param [Hash<Symbol, Object>] result
       # @param [Symbol] total_color
       def convert(result, total_color:)
-        case
-        when result[:value]
+        if result[:value]
           colorize(total_color, "total number of unique #{humanize_code(result[:code])} factories & traits: #{result[:value]}")
-        when result[:factory_names] && result[:trait_name]
+        elsif result[:factory_names] && result[:trait_name]
           append_definition_path(result) { "#{humanize_code(result[:code])} trait #{colorize(:blue, result[:trait_name])} of factory #{list(result[:factory_names])}" }
-        when result[:factory_names]
+        elsif result[:factory_names]
           append_definition_path(result) { "#{humanize_code(result[:code])} factory #{list(result[:factory_names])}" }
         else
           append_definition_path(result) { "#{humanize_code(result[:code])} global trait #{colorize(:blue, result[:trait_name])}" }

--- a/lib/factory_trace/writers/report_writer.rb
+++ b/lib/factory_trace/writers/report_writer.rb
@@ -10,7 +10,7 @@ module FactoryTrace
 
       CODES = {
         used: "used",
-        unused: "unused",
+        unused: "unused"
       }.freeze
 
       # @param [Array<Hash>] results

--- a/lib/factory_trace/writers/trace_writer.rb
+++ b/lib/factory_trace/writers/trace_writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Writers
     class TraceWriter < Writer

--- a/lib/factory_trace/writers/writer.rb
+++ b/lib/factory_trace/writers/writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FactoryTrace
   module Writers
     class Writer

--- a/lib/integrations/rspec.rb
+++ b/lib/integrations/rspec.rb
@@ -2,4 +2,3 @@ RSpec.configure do |config|
   config.before(:suite) { FactoryTrace.start }
   config.after(:suite) { FactoryTrace.stop }
 end
-

--- a/lib/integrations/rspec.rb
+++ b/lib/integrations/rspec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:suite) { FactoryTrace.start }
   config.after(:suite) { FactoryTrace.stop }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   attr_accessor :name, :phone, :email, :address
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,10 +15,10 @@ end
 
 FactoryBot.define do
   factory :user do
-    name { 'name' }
+    name { "name" }
 
     trait :with_phone do
-      phone { 'phone' }
+      phone { "phone" }
     end
 
     factory :user_with_defaults, traits: %i[with_address with_phone]
@@ -26,7 +26,7 @@ FactoryBot.define do
 
   factory :admin, parent: :user do
     trait :with_email do
-      email { 'email' }
+      email { "email" }
     end
 
     trait :combination do
@@ -52,6 +52,6 @@ FactoryBot.define do
   end
 
   trait :with_address do
-    address { 'address' }
+    address { "address" }
   end
 end

--- a/spec/factory_trace/helpers/converter_spec.rb
+++ b/spec/factory_trace/helpers/converter_spec.rb
@@ -2,23 +2,23 @@
 
 RSpec.describe FactoryTrace::Helpers::Converter do
   describe ".trait" do
-    subject { described_class.trait(trait) }
+    subject(:structure) { described_class.trait(trait) }
 
     let(:trait) { find_global_trait("with_address") }
 
     specify do
-      expect(subject).to eq(FactoryTrace::Structures::Trait.new("with_address"))
+      expect(structure).to eq(FactoryTrace::Structures::Trait.new("with_address"))
     end
   end
 
   describe ".factory" do
-    subject { described_class.factory(factory) }
+    subject(:structure) { described_class.factory(factory) }
 
     context "when has no traits" do
       let(:factory) { find_factory(:manager) }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["manager"], [], parent_name: "admin", declaration_names: ["with_phone"]))
+        expect(structure).to eq(FactoryTrace::Structures::Factory.new(["manager"], [], parent_name: "admin", declaration_names: ["with_phone"]))
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe FactoryTrace::Helpers::Converter do
       let(:factory) { find_factory(:user) }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["user"], [FactoryTrace::Structures::Trait.new("with_phone")]))
+        expect(structure).to eq(FactoryTrace::Structures::Factory.new(["user"], [FactoryTrace::Structures::Trait.new("with_phone")]))
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe FactoryTrace::Helpers::Converter do
       let(:factory) { find_factory("article") }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["article", "post"], []))
+        expect(structure).to eq(FactoryTrace::Structures::Factory.new(["article", "post"], []))
       end
     end
   end

--- a/spec/factory_trace/helpers/converter_spec.rb
+++ b/spec/factory_trace/helpers/converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Helpers::Converter do
   describe ".trait" do
     subject { described_class.trait(trait) }

--- a/spec/factory_trace/helpers/converter_spec.rb
+++ b/spec/factory_trace/helpers/converter_spec.rb
@@ -1,38 +1,38 @@
 RSpec.describe FactoryTrace::Helpers::Converter do
-  describe '.trait' do
+  describe ".trait" do
     subject { described_class.trait(trait) }
 
-    let(:trait) { find_global_trait('with_address') }
+    let(:trait) { find_global_trait("with_address") }
 
     specify do
-      expect(subject).to eq(FactoryTrace::Structures::Trait.new('with_address'))
+      expect(subject).to eq(FactoryTrace::Structures::Trait.new("with_address"))
     end
   end
 
-  describe '.factory' do
+  describe ".factory" do
     subject { described_class.factory(factory) }
 
-    context 'when has no traits' do
+    context "when has no traits" do
       let(:factory) { find_factory(:manager) }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(['manager'], [], parent_name: 'admin', declaration_names: ['with_phone']))
+        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["manager"], [], parent_name: "admin", declaration_names: ["with_phone"]))
       end
     end
 
-    context 'when has traits' do
+    context "when has traits" do
       let(:factory) { find_factory(:user) }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(['user'], [FactoryTrace::Structures::Trait.new('with_phone')]))
+        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["user"], [FactoryTrace::Structures::Trait.new("with_phone")]))
       end
     end
 
-    context 'when has aliases' do
-      let(:factory) { find_factory('article') }
+    context "when has aliases" do
+      let(:factory) { find_factory("article") }
 
       specify do
-        expect(subject).to eq(FactoryTrace::Structures::Factory.new(['article', 'post'], []))
+        expect(subject).to eq(FactoryTrace::Structures::Factory.new(["article", "post"], []))
       end
     end
   end

--- a/spec/factory_trace/integration_tests/empty_spec.rb
+++ b/spec/factory_trace/integration_tests/empty_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace do
   it "uses nothing" do
   end

--- a/spec/factory_trace/integration_tests/empty_spec.rb
+++ b/spec/factory_trace/integration_tests/empty_spec.rb
@@ -1,4 +1,4 @@
 RSpec.describe FactoryTrace do
-  it 'uses nothing' do
+  it "uses nothing" do
   end
 end

--- a/spec/factory_trace/integration_tests/expected.txt
+++ b/spec/factory_trace/integration_tests/expected.txt
@@ -1,14 +1,14 @@
 total number of unique used factories & traits: 0
 total number of unique unused factories & traits: 12
-unused factory user => spec/factories.rb:17
-unused trait with_phone of factory user => spec/factories.rb:20
-unused factory user_with_defaults => spec/factories.rb:24
-unused factory admin => spec/factories.rb:27
-unused trait with_email of factory admin => spec/factories.rb:28
-unused trait combination of factory admin => spec/factories.rb:32
-unused factory manager => spec/factories.rb:38
-unused factory company => spec/factories.rb:42
-unused trait with_manager of factory company => spec/factories.rb:43
-unused factory article, post => spec/factories.rb:48
-unused factory comment => spec/factories.rb:50
-unused global trait with_address => spec/factories.rb:54
+unused factory user => spec/factories.rb:19
+unused trait with_phone of factory user => spec/factories.rb:22
+unused factory user_with_defaults => spec/factories.rb:26
+unused factory admin => spec/factories.rb:29
+unused trait with_email of factory admin => spec/factories.rb:30
+unused trait combination of factory admin => spec/factories.rb:34
+unused factory manager => spec/factories.rb:40
+unused factory company => spec/factories.rb:44
+unused trait with_manager of factory company => spec/factories.rb:45
+unused factory article, post => spec/factories.rb:50
+unused factory comment => spec/factories.rb:52
+unused global trait with_address => spec/factories.rb:56

--- a/spec/factory_trace/integration_tests/runner.rb
+++ b/spec/factory_trace/integration_tests/runner.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "tempfile"
 

--- a/spec/factory_trace/integration_tests/runner.rb
+++ b/spec/factory_trace/integration_tests/runner.rb
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 
-require 'tempfile'
+require "tempfile"
 
-result_tempfile = Tempfile.new('integration-test-results.txt')
-deprecation_tempfile = Tempfile.new('integration-test-deprecations.txt')
+result_tempfile = Tempfile.new("integration-test-results.txt")
+deprecation_tempfile = Tempfile.new("integration-test-deprecations.txt")
 `FB_TRACE_FILE=#{result_tempfile.path} bundle exec rspec spec/factory_trace/integration_tests/ 2> #{deprecation_tempfile.path}`
 
 result = File.read(result_tempfile)
-expected = File.read('spec/factory_trace/integration_tests/expected.txt')
+expected = File.read("spec/factory_trace/integration_tests/expected.txt")
 
 abort("Got:\n#{result}\nExpected:\n#{expected}") if result != expected
 

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
             ]
           ),
           FactoryTrace::Structures::Factory.new(["article", "post"], []),
-          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"]),
+          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"])
         ],
         [
           FactoryTrace::Structures::Trait.new("with_address")

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -1,42 +1,42 @@
 RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
-  describe '.call' do
+  describe ".call" do
     subject { described_class.call }
 
     specify do
       collection = FactoryTrace::Structures::Collection.new(
         [
           FactoryTrace::Structures::Factory.new(
-            ['user'],
+            ["user"],
             [
-              FactoryTrace::Structures::Trait.new('with_phone')
+              FactoryTrace::Structures::Trait.new("with_phone")
             ]
           ),
           FactoryTrace::Structures::Factory.new(
-            ['user_with_defaults'],
+            ["user_with_defaults"],
             [],
-            declaration_names: ['with_address', 'with_phone'],
-            parent_name: 'user'
+            declaration_names: ["with_address", "with_phone"],
+            parent_name: "user"
           ),
           FactoryTrace::Structures::Factory.new(
-            ['admin'],
+            ["admin"],
             [
-              FactoryTrace::Structures::Trait.new('with_email'),
-              FactoryTrace::Structures::Trait.new('combination', declaration_names: ['with_email', 'with_phone'])
+              FactoryTrace::Structures::Trait.new("with_email"),
+              FactoryTrace::Structures::Trait.new("combination", declaration_names: ["with_email", "with_phone"])
             ],
-            parent_name: 'user'
+            parent_name: "user"
           ),
-          FactoryTrace::Structures::Factory.new(['manager'], [], parent_name: 'admin', declaration_names: ['with_phone']),
+          FactoryTrace::Structures::Factory.new(["manager"], [], parent_name: "admin", declaration_names: ["with_phone"]),
           FactoryTrace::Structures::Factory.new(
-            ['company'],
+            ["company"],
             [
-              FactoryTrace::Structures::Trait.new('with_manager', declaration_names: ['manager'])
+              FactoryTrace::Structures::Trait.new("with_manager", declaration_names: ["manager"])
             ]
           ),
-          FactoryTrace::Structures::Factory.new(['article', 'post'], []),
-          FactoryTrace::Structures::Factory.new(['comment'], [], declaration_names: ['post']),
+          FactoryTrace::Structures::Factory.new(["article", "post"], []),
+          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"]),
         ],
         [
-          FactoryTrace::Structures::Trait.new('with_address')
+          FactoryTrace::Structures::Trait.new("with_address")
         ]
       )
 

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
   describe ".call" do
-    subject { described_class.call }
+    subject(:structure) { described_class.call }
 
     specify do
       collection = FactoryTrace::Structures::Collection.new(
@@ -42,7 +42,7 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
         ]
       )
 
-      expect(subject).to eq(collection)
+      expect(structure).to eq(collection)
     end
   end
 end

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
   describe ".call" do
     subject { described_class.call }

--- a/spec/factory_trace/preprocessors/extract_used_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_used_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Preprocessors::ExtractUsed do
   describe ".call" do
     subject { described_class.call({"admin" => Set.new(["with_address"])}) }

--- a/spec/factory_trace/preprocessors/extract_used_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_used_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe FactoryTrace::Preprocessors::ExtractUsed do
-  describe '.call' do
-    subject { described_class.call({'admin' => Set.new(['with_address'])}) }
+  describe ".call" do
+    subject { described_class.call({"admin" => Set.new(["with_address"])}) }
 
     specify do
       collection = FactoryTrace::Structures::Collection.new(
         [
           FactoryTrace::Structures::Factory.new(
-            ['admin'],
-            [FactoryTrace::Structures::Trait.new('with_address')]
+            ["admin"],
+            [FactoryTrace::Structures::Trait.new("with_address")]
           )
         ],
         []

--- a/spec/factory_trace/preprocessors/extract_used_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_used_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe FactoryTrace::Preprocessors::ExtractUsed do
   describe ".call" do
-    subject { described_class.call({"admin" => Set.new(["with_address"])}) }
+    subject(:structure) { described_class.call({"admin" => Set.new(["with_address"])}) }
 
     specify do
       collection = FactoryTrace::Structures::Collection.new(
@@ -15,7 +15,7 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractUsed do
         []
       )
 
-      expect(subject).to eq(collection)
+      expect(structure).to eq(collection)
     end
   end
 end

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
-          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["comment"]}
         ])
       end
     end

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -1,159 +1,159 @@
 RSpec.describe FactoryTrace::Processors::FindUnused do
   subject(:checker) { described_class.call(FactoryTrace::Preprocessors::ExtractDefined.call, FactoryTrace::Preprocessors::ExtractUsed.call(data)) }
 
-  describe 'check!' do
-    context 'when all factories are not used' do
+  describe "check!" do
+    context "when all factories are not used" do
       let(:data) { {} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 0},
           {code: :unused, value: 12},
-          {code: :unused, factory_names: ['user']},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user"]},
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when a factory used through alias' do
-      let(:data) { {'post' => Set.new} }
+    context "when a factory used through alias" do
+      let(:data) { {"post" => Set.new} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
           {code: :unused, value: 11},
-          {code: :unused, factory_names: ['user']},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user"]},
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when a factory was used without its traits' do
-      let(:data) { {'user' => Set.new} }
+    context "when a factory was used without its traits" do
+      let(:data) { {"user" => Set.new} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
           {code: :unused, value: 11},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when a factory was used with its traits' do
-      let(:data) { {'user' => Set.new(['with_phone'])} }
+    context "when a factory was used with its traits" do
+      let(:data) { {"user" => Set.new(["with_phone"])} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
           {code: :unused, value: 10},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when a child factory was used' do
-      let(:data) { {'admin' => []} }
+    context "when a child factory was used" do
+      let(:data) { {"admin" => []} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
           {code: :unused, value: 10},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when a global trait was used' do
-      let(:data) { {'user' => Set.new(['with_address'])} }
+    context "when a global trait was used" do
+      let(:data) { {"user" => Set.new(["with_address"])} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
           {code: :unused, value: 10},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']}
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]}
         ])
       end
     end
 
-    context 'when a parent trait was used' do
-      let(:data) { {'admin' => Set.new(['with_phone'])} }
+    context "when a parent trait was used" do
+      let(:data) { {"admin" => Set.new(["with_phone"])} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 3},
           {code: :unused, value: 9},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when everything were used' do
-      let(:data) { {'admin' => Set.new(['with_phone', 'with_email', 'combination']), 'company' => Set.new(['with_address', 'with_manager']), 'article' => Set.new, 'comment' => Set.new, 'manager' => Set.new, 'user_with_defaults' => Set.new} }
+    context "when everything were used" do
+      let(:data) { {"admin" => Set.new(["with_phone", "with_email", "combination"]), "company" => Set.new(["with_address", "with_manager"]), "article" => Set.new, "comment" => Set.new, "manager" => Set.new, "user_with_defaults" => Set.new} }
 
       specify do
         expect(checker).to eq([
@@ -163,96 +163,96 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       end
     end
 
-    context 'when trait is used indirectly through another trait' do
-      let(:data) { {'admin' => Set.new(['combination'])} }
+    context "when trait is used indirectly through another trait" do
+      let(:data) { {"admin" => Set.new(["combination"])} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 5},
           {code: :unused, value: 7},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when trait is used indirectly through factory' do
-      let(:data) { {'manager' => Set.new} }
+    context "when trait is used indirectly through factory" do
+      let(:data) { {"manager" => Set.new} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
           {code: :unused, value: 8},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when factory is used indirectly through factory' do
-      let(:data) { {'comment' => Set.new} }
+    context "when factory is used indirectly through factory" do
+      let(:data) { {"comment" => Set.new} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
           {code: :unused, value: 10},
-          {code: :unused, factory_names: ['user']},
-          {code: :unused, factory_names: ['user'], trait_name: 'with_phone'},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user"]},
+          {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when factory is used indirectly through trait' do
-      let(:data) { {'company' => Set.new(['with_manager'])} }
+    context "when factory is used indirectly through trait" do
+      let(:data) { {"company" => Set.new(["with_manager"])} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 6},
           {code: :unused, value: 6},
-          {code: :unused, factory_names: ['user_with_defaults']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
-          {code: :unused, trait_name: 'with_address'}
+          {code: :unused, factory_names: ["user_with_defaults"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
-    context 'when factory with default traits was used' do
-      let(:data) { {'user_with_defaults' => Set.new} }
+    context "when factory with default traits was used" do
+      let(:data) { {"user_with_defaults" => Set.new} }
 
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
           {code: :unused, value: 8},
-          {code: :unused, factory_names: ['admin']},
-          {code: :unused, factory_names: ['admin'], trait_name: 'with_email'},
-          {code: :unused, factory_names: ['admin'], trait_name: 'combination'},
-          {code: :unused, factory_names: ['manager']},
-          {code: :unused, factory_names: ['company']},
-          {code: :unused, factory_names: ['company'], trait_name: 'with_manager'},
-          {code: :unused, factory_names: ['article', 'post']},
-          {code: :unused, factory_names: ['comment']},
+          {code: :unused, factory_names: ["admin"]},
+          {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
+          {code: :unused, factory_names: ["admin"], trait_name: "combination"},
+          {code: :unused, factory_names: ["manager"]},
+          {code: :unused, factory_names: ["company"]},
+          {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["article", "post"]},
+          {code: :unused, factory_names: ["comment"]},
         ])
       end
     end

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
     end
 
     context 'when trait is used indirectly through factory' do
-      let(:data) { {'manager' => Set.new } }
+      let(:data) { {'manager' => Set.new} }
 
       specify do
         expect(checker).to eq([

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Processors::FindUnused do
   subject(:checker) { described_class.call(FactoryTrace::Preprocessors::ExtractDefined.call, FactoryTrace::Preprocessors::ExtractUsed.call(data)) }
 

--- a/spec/factory_trace/readers/trace_reader_spec.rb
+++ b/spec/factory_trace/readers/trace_reader_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
                 FactoryTrace::Structures::Trait.new("combination", declaration_names: ["with_email", "with_phone"])
               ],
               parent_name: "user"
-            ),
+            )
           ],
           [
             FactoryTrace::Structures::Trait.new("with_address")

--- a/spec/factory_trace/readers/trace_reader_spec.rb
+++ b/spec/factory_trace/readers/trace_reader_spec.rb
@@ -4,156 +4,156 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
   describe '.read_from_files' do
     let(:input1) do
       <<~TEXT
-      {
-        "defined": {
-          "factories": [
-            {
-              "names": [
-                "user"
-              ],
-              "traits": [
-                {
-                  "name": "with_phone",
-                  "declaration_names": []
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            },
-            {
-              "names": [
-                "admin"
-              ],
-              "traits": [
-                {
-                  "name": "with_email",
-                  "declaration_names": []
-                },
-                {
-                  "name": "combination",
-                  "declaration_names": [
-                    "with_email",
-                    "with_phone"
-                  ]
-                }
-              ],
-              "parent_name": "user",
-              "declaration_names": []
-            }
-          ],
-          "traits": [
-            {
-              "name": "with_address",
-              "declaration_names": []
-            }
-          ]
-        },
-        "used": {
-          "factories": [
-            {
-              "names": [
-                "user"
-              ],
-              "traits": [
-                {
-                  "name": "with_phone",
-                  "declaration_names": []
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            },
-            {
-              "names": [
-                "admin"
-              ],
-              "traits": [
-                {
-                  "name": "with_email",
-                  "declaration_names": []
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            }
-          ],
-          "traits": []
+        {
+          "defined": {
+            "factories": [
+              {
+                "names": [
+                  "user"
+                ],
+                "traits": [
+                  {
+                    "name": "with_phone",
+                    "declaration_names": []
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              },
+              {
+                "names": [
+                  "admin"
+                ],
+                "traits": [
+                  {
+                    "name": "with_email",
+                    "declaration_names": []
+                  },
+                  {
+                    "name": "combination",
+                    "declaration_names": [
+                      "with_email",
+                      "with_phone"
+                    ]
+                  }
+                ],
+                "parent_name": "user",
+                "declaration_names": []
+              }
+            ],
+            "traits": [
+              {
+                "name": "with_address",
+                "declaration_names": []
+              }
+            ]
+          },
+          "used": {
+            "factories": [
+              {
+                "names": [
+                  "user"
+                ],
+                "traits": [
+                  {
+                    "name": "with_phone",
+                    "declaration_names": []
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              },
+              {
+                "names": [
+                  "admin"
+                ],
+                "traits": [
+                  {
+                    "name": "with_email",
+                    "declaration_names": []
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              }
+            ],
+            "traits": []
+          }
         }
-      }
       TEXT
     end
 
     let(:input2) do
       <<~TEXT
-      {
-        "defined": {
-          "factories": [
-            {
-              "names": [
-                "user"
-              ],
-              "traits": [
-                {
-                  "name": "with_phone",
-                  "declaration_names": []
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            },
-            {
-              "names": [
-                "admin"
-              ],
-              "traits": [
-                {
-                  "name": "with_email",
-                  "declaration_names": []
-                },
-                {
-                  "name": "combination",
-                  "declaration_names": [
-                    "with_email",
-                    "with_phone"
-                  ]
-                }
-              ],
-              "parent_name": "user",
-              "declaration_names": []
-            }
-          ],
-          "traits": [
-            {
-              "name": "with_address",
-              "declaration_names": []
-            }
-          ]
-        },
-        "used": {
-          "factories": [
-            {
-              "names": [
-                "user"
-              ],
-              "traits": [
-                {
-                  "name": "with_address",
-                  "declaration_names": []
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            },
-            {
-              "names": ["admin"],
-              "traits": [],
-              "parent_name": null,
-              "declaration_names": []
-            }
-          ],
-          "traits": []
+        {
+          "defined": {
+            "factories": [
+              {
+                "names": [
+                  "user"
+                ],
+                "traits": [
+                  {
+                    "name": "with_phone",
+                    "declaration_names": []
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              },
+              {
+                "names": [
+                  "admin"
+                ],
+                "traits": [
+                  {
+                    "name": "with_email",
+                    "declaration_names": []
+                  },
+                  {
+                    "name": "combination",
+                    "declaration_names": [
+                      "with_email",
+                      "with_phone"
+                    ]
+                  }
+                ],
+                "parent_name": "user",
+                "declaration_names": []
+              }
+            ],
+            "traits": [
+              {
+                "name": "with_address",
+                "declaration_names": []
+              }
+            ]
+          },
+          "used": {
+            "factories": [
+              {
+                "names": [
+                  "user"
+                ],
+                "traits": [
+                  {
+                    "name": "with_address",
+                    "declaration_names": []
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              },
+              {
+                "names": ["admin"],
+                "traits": [],
+                "parent_name": null,
+                "declaration_names": []
+              }
+            ],
+            "traits": []
+          }
         }
-      }
       TEXT
     end
 
@@ -212,40 +212,40 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
   describe '#read' do
     let(:input) do
       StringIO.new <<~TEXT
-      {
-        "defined": {
-          "factories": [
-            {
-              "names": ["user"],
-              "traits": [
-                {
-                  "name": "with_phone",
-                  "declaration_names": []
-                },
-                {
-                  "name": "combination",
-                  "declaration_names": [
-                    "with_email",
-                    "with_phone"
-                  ]
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": []
-            }
-          ],
-          "traits": [
-            {
-              "name": "with_address",
-              "declaration_names": []
-            }
-          ]
-        },
-        "used": {
-          "factories": [],
-          "traits": []
+        {
+          "defined": {
+            "factories": [
+              {
+                "names": ["user"],
+                "traits": [
+                  {
+                    "name": "with_phone",
+                    "declaration_names": []
+                  },
+                  {
+                    "name": "combination",
+                    "declaration_names": [
+                      "with_email",
+                      "with_phone"
+                    ]
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": []
+              }
+            ],
+            "traits": [
+              {
+                "name": "with_address",
+                "declaration_names": []
+              }
+            ]
+          },
+          "used": {
+            "factories": [],
+            "traits": []
+          }
         }
-      }
       TEXT
     end
 

--- a/spec/factory_trace/readers/trace_reader_spec.rb
+++ b/spec/factory_trace/readers/trace_reader_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FactoryTrace::Readers::TraceReader do
   subject(:reader) { described_class.new(input) }
 
-  describe '.read_from_files' do
+  describe ".read_from_files" do
     let(:input1) do
       <<~TEXT
         {
@@ -157,8 +157,8 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
       TEXT
     end
 
-    let(:file1) { Tempfile.new('file1.txt') }
-    let(:file2) { Tempfile.new('file2.txt') }
+    let(:file1) { Tempfile.new("file1.txt") }
+    let(:file2) { Tempfile.new("file2.txt") }
 
     before do
       file1.write(input1)
@@ -167,39 +167,39 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
       file2.rewind
     end
 
-    it 'reads' do
+    it "reads" do
       result = {
         defined: FactoryTrace::Structures::Collection.new(
           [
             FactoryTrace::Structures::Factory.new(
-              ['user'],
-              [FactoryTrace::Structures::Trait.new('with_phone')]
+              ["user"],
+              [FactoryTrace::Structures::Trait.new("with_phone")]
             ),
             FactoryTrace::Structures::Factory.new(
-              ['admin'],
+              ["admin"],
               [
-                FactoryTrace::Structures::Trait.new('with_email'),
-                FactoryTrace::Structures::Trait.new('combination', declaration_names: ['with_email', 'with_phone'])
+                FactoryTrace::Structures::Trait.new("with_email"),
+                FactoryTrace::Structures::Trait.new("combination", declaration_names: ["with_email", "with_phone"])
               ],
-              parent_name: 'user'
+              parent_name: "user"
             ),
           ],
           [
-            FactoryTrace::Structures::Trait.new('with_address')
+            FactoryTrace::Structures::Trait.new("with_address")
           ]
         ),
         used: FactoryTrace::Structures::Collection.new(
           [
             FactoryTrace::Structures::Factory.new(
-              ['user'],
+              ["user"],
               [
-                FactoryTrace::Structures::Trait.new('with_phone'),
-                FactoryTrace::Structures::Trait.new('with_address')
+                FactoryTrace::Structures::Trait.new("with_phone"),
+                FactoryTrace::Structures::Trait.new("with_address")
               ]
             ),
             FactoryTrace::Structures::Factory.new(
-              ['admin'],
-              [FactoryTrace::Structures::Trait.new('with_email')]
+              ["admin"],
+              [FactoryTrace::Structures::Trait.new("with_email")]
             )
           ]
         )
@@ -209,7 +209,7 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
     end
   end
 
-  describe '#read' do
+  describe "#read" do
     let(:input) do
       StringIO.new <<~TEXT
         {
@@ -249,20 +249,20 @@ RSpec.describe FactoryTrace::Readers::TraceReader do
       TEXT
     end
 
-    it 'reads' do
+    it "reads" do
       result = {
         defined: FactoryTrace::Structures::Collection.new(
           [
             FactoryTrace::Structures::Factory.new(
-              ['user'],
+              ["user"],
               [
-                FactoryTrace::Structures::Trait.new('with_phone'),
-                FactoryTrace::Structures::Trait.new('combination', declaration_names: ['with_email', 'with_phone'])
+                FactoryTrace::Structures::Trait.new("with_phone"),
+                FactoryTrace::Structures::Trait.new("combination", declaration_names: ["with_email", "with_phone"])
               ]
             )
           ],
           [
-            FactoryTrace::Structures::Trait.new('with_address')
+            FactoryTrace::Structures::Trait.new("with_address")
           ]
         ),
         used: FactoryTrace::Structures::Collection.new

--- a/spec/factory_trace/readers/trace_reader_spec.rb
+++ b/spec/factory_trace/readers/trace_reader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Readers::TraceReader do
   subject(:reader) { described_class.new(input) }
 

--- a/spec/factory_trace/structures/collection_spec.rb
+++ b/spec/factory_trace/structures/collection_spec.rb
@@ -19,8 +19,10 @@ RSpec.describe FactoryTrace::Structures::Collection do
       let(:element) { FactoryTrace::Structures::Factory.new(["name"], []) }
 
       specify do
-        expect(subject).to eq(element)
-        expect(collection.factories).to eq([element])
+        aggregate_failures do
+          expect(subject).to eq(element)
+          expect(collection.factories).to eq([element])
+        end
       end
     end
 
@@ -28,8 +30,10 @@ RSpec.describe FactoryTrace::Structures::Collection do
       let(:element) { FactoryTrace::Structures::Trait.new("name") }
 
       specify do
-        expect(subject).to eq(element)
-        expect(collection.traits).to eq([element])
+        aggregate_failures do
+          expect(subject).to eq(element)
+          expect(collection.traits).to eq([element])
+        end
       end
     end
   end

--- a/spec/factory_trace/structures/collection_spec.rb
+++ b/spec/factory_trace/structures/collection_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe FactoryTrace::Structures::Collection do
   end
 
   describe "#add" do
-    subject { collection.add(element) }
+    subject(:structure) { collection.add(element) }
 
     context "when element is a factory" do
       let(:element) { FactoryTrace::Structures::Factory.new(["name"], []) }
 
       specify do
         aggregate_failures do
-          expect(subject).to eq(element)
+          expect(structure).to eq(element)
           expect(collection.factories).to eq([element])
         end
       end
@@ -31,7 +31,7 @@ RSpec.describe FactoryTrace::Structures::Collection do
 
       specify do
         aggregate_failures do
-          expect(subject).to eq(element)
+          expect(structure).to eq(element)
           expect(collection.traits).to eq([element])
         end
       end

--- a/spec/factory_trace/structures/collection_spec.rb
+++ b/spec/factory_trace/structures/collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Structures::Collection do
   subject(:collection) { described_class.new(factories, traits) }
 

--- a/spec/factory_trace/structures/collection_spec.rb
+++ b/spec/factory_trace/structures/collection_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe FactoryTrace::Structures::Collection do
   let(:factories) { [] }
   let(:traits) { [] }
 
-  describe '#to_h' do
+  describe "#to_h" do
     subject { collection.to_h }
 
     it { is_expected.to eq({factories: [], traits: []}) }
   end
 
-  describe '#add' do
+  describe "#add" do
     subject { collection.add(element) }
 
-    context 'when element is a factory' do
-      let(:element) { FactoryTrace::Structures::Factory.new(['name'], []) }
+    context "when element is a factory" do
+      let(:element) { FactoryTrace::Structures::Factory.new(["name"], []) }
 
       specify do
         expect(subject).to eq(element)
@@ -22,8 +22,8 @@ RSpec.describe FactoryTrace::Structures::Collection do
       end
     end
 
-    context 'when element is a trait' do
-      let(:element) { FactoryTrace::Structures::Trait.new('name') }
+    context "when element is a trait" do
+      let(:element) { FactoryTrace::Structures::Trait.new("name") }
 
       specify do
         expect(subject).to eq(element)
@@ -32,7 +32,7 @@ RSpec.describe FactoryTrace::Structures::Collection do
     end
   end
 
-  describe '#total' do
+  describe "#total" do
     subject { collection.total }
 
     it { is_expected.to eq(0) }

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe FactoryTrace::Structures::Factory do
   let(:opts) { {} }
 
   describe "#to_h" do
-    subject { factory.to_h }
+    subject(:hash) { factory.to_h }
 
     specify do
-      expect(subject).to eq({
+      expect(hash).to eq({
         names: ["user", "person"],
         traits: [{name: "special", declaration_names: [], definition_path: nil}],
         parent_name: nil,

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe FactoryTrace::Structures::Factory do
   subject(:factory) { described_class.new(names, traits, **opts) }
 
-  let(:names) { ['user', 'person'] }
-  let(:traits) { [FactoryTrace::Structures::Trait.new('special')] }
+  let(:names) { ["user", "person"] }
+  let(:traits) { [FactoryTrace::Structures::Trait.new("special")] }
   let(:opts) { {} }
 
-  describe '#to_h' do
+  describe "#to_h" do
     subject { factory.to_h }
 
     specify do
       expect(subject).to eq({
-        names: ['user', 'person'],
-        traits: [{name: 'special', declaration_names: [], definition_path: nil}],
+        names: ["user", "person"],
+        traits: [{name: "special", declaration_names: [], definition_path: nil}],
         parent_name: nil,
         declaration_names: [],
         definition_path: nil

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe FactoryTrace::Structures::Factory do
 
     specify do
       expect(subject).to eq({
-                              names: ['user', 'person'],
-                              traits: [{name: 'special', declaration_names: [], definition_path: nil}],
-                              parent_name: nil,
-                              declaration_names: [],
-                              definition_path: nil
-                            })
+        names: ['user', 'person'],
+        traits: [{name: 'special', declaration_names: [], definition_path: nil}],
+        parent_name: nil,
+        declaration_names: [],
+        definition_path: nil
+      })
     end
   end
 end

--- a/spec/factory_trace/structures/factory_spec.rb
+++ b/spec/factory_trace/structures/factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Structures::Factory do
   subject(:factory) { described_class.new(names, traits, **opts) }
 

--- a/spec/factory_trace/structures/trait_spec.rb
+++ b/spec/factory_trace/structures/trait_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Structures::Trait do
   subject(:trait) { described_class.new(name) }
 

--- a/spec/factory_trace/structures/trait_spec.rb
+++ b/spec/factory_trace/structures/trait_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe FactoryTrace::Structures::Trait do
   subject(:trait) { described_class.new(name) }
 
-  let(:name) { 'something' }
+  let(:name) { "something" }
 
-  describe '#to_h' do
+  describe "#to_h" do
     subject { trait.to_h }
 
-    it { is_expected.to eq({name: 'something', declaration_names: [], definition_path: nil}) }
+    it { is_expected.to eq({name: "something", declaration_names: [], definition_path: nil}) }
   end
 end

--- a/spec/factory_trace/tracker_spec.rb
+++ b/spec/factory_trace/tracker_spec.rb
@@ -1,33 +1,33 @@
 RSpec.describe FactoryTrace::Tracker do
   subject(:tracker) { described_class.new }
 
-  describe '#track!' do
+  describe "#track!" do
     before { tracker.track! }
 
-    it 'collects used factories without traits' do
+    it "collects used factories without traits" do
       build(:user)
 
-      expect(tracker.storage).to eq('user' => Set.new)
+      expect(tracker.storage).to eq("user" => Set.new)
     end
 
-    it 'collects used factories with traits' do
+    it "collects used factories with traits" do
       build(:user, :with_phone)
 
-      expect(tracker.storage).to eq('user' => Set.new(['with_phone']))
+      expect(tracker.storage).to eq("user" => Set.new(["with_phone"]))
     end
 
-    it 'collects used factories with global traits' do
+    it "collects used factories with global traits" do
       build(:user, :with_address)
 
-      expect(tracker.storage).to eq('user' => Set.new(['with_address']))
+      expect(tracker.storage).to eq("user" => Set.new(["with_address"]))
     end
 
-    it 'collects all used factories' do
+    it "collects all used factories" do
       build(:user)
       build(:admin, :with_phone, :with_email)
       build(:company, :with_address)
 
-      expect(tracker.storage).to eq('user' => Set.new, 'admin' => Set.new(['with_phone', 'with_email']), 'company' => Set.new(['with_address']))
+      expect(tracker.storage).to eq("user" => Set.new, "admin" => Set.new(["with_phone", "with_email"]), "company" => Set.new(["with_address"]))
     end
   end
 end

--- a/spec/factory_trace/tracker_spec.rb
+++ b/spec/factory_trace/tracker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Tracker do
   subject(:tracker) { described_class.new }
 

--- a/spec/factory_trace/writers/report_writer_spec.rb
+++ b/spec/factory_trace/writers/report_writer_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe FactoryTrace::Writers::ReportWriter do
   subject(:printer) { described_class.new(output) }
 
-  describe '#print' do
+  describe "#print" do
     let(:output) { StringIO.new }
     let(:results) do
       [
@@ -13,7 +13,7 @@ RSpec.describe FactoryTrace::Writers::ReportWriter do
       ]
     end
 
-    it 'prints the result' do
+    it "prints the result" do
       printer.write(results)
 
       expect(output.string).to eq(<<~TEXT)

--- a/spec/factory_trace/writers/report_writer_spec.rb
+++ b/spec/factory_trace/writers/report_writer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Writers::ReportWriter do
   subject(:printer) { described_class.new(output) }
 

--- a/spec/factory_trace/writers/trace_writer_spec.rb
+++ b/spec/factory_trace/writers/trace_writer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe FactoryTrace::Writers::TraceWriter do
   subject(:printer) { described_class.new(output) }
 

--- a/spec/factory_trace/writers/trace_writer_spec.rb
+++ b/spec/factory_trace/writers/trace_writer_spec.rb
@@ -1,29 +1,29 @@
 RSpec.describe FactoryTrace::Writers::TraceWriter do
   subject(:printer) { described_class.new(output) }
 
-  describe '#print' do
+  describe "#print" do
     let(:output) { StringIO.new }
     let(:defined) do
       FactoryTrace::Structures::Collection.new(
         [
           FactoryTrace::Structures::Factory.new(
-            ['user'],
+            ["user"],
             [
-              FactoryTrace::Structures::Trait.new('with_phone')
+              FactoryTrace::Structures::Trait.new("with_phone")
             ]
           ),
           FactoryTrace::Structures::Factory.new(
-            ['admin'],
+            ["admin"],
             [
-              FactoryTrace::Structures::Trait.new('with_email'),
-              FactoryTrace::Structures::Trait.new('combination', declaration_names: ['with_email', 'with_phone'])
+              FactoryTrace::Structures::Trait.new("with_email"),
+              FactoryTrace::Structures::Trait.new("combination", declaration_names: ["with_email", "with_phone"])
             ],
-            parent_name: 'user',
-            definition_path: 'path/to/file:10'
+            parent_name: "user",
+            definition_path: "path/to/file:10"
           )
         ],
         [
-          FactoryTrace::Structures::Trait.new('with_address')
+          FactoryTrace::Structures::Trait.new("with_address")
         ]
       )
     end
@@ -32,7 +32,7 @@ RSpec.describe FactoryTrace::Writers::TraceWriter do
       FactoryTrace::Structures::Collection.new({}, {})
     end
 
-    it 'prints the result' do
+    it "prints the result" do
       printer.write(defined, used)
 
       expect(output.string).to eq(<<~TEXT)

--- a/spec/factory_trace/writers/trace_writer_spec.rb
+++ b/spec/factory_trace/writers/trace_writer_spec.rb
@@ -36,75 +36,75 @@ RSpec.describe FactoryTrace::Writers::TraceWriter do
       printer.write(defined, used)
 
       expect(output.string).to eq(<<~TEXT)
-      {
-        "defined": {
-          "factories": [
-            {
-              "names": [
-                "user"
-              ],
-              "traits": [
-                {
-                  "name": "with_phone",
-                  "declaration_names": [
-      
-                  ],
-                  "definition_path": null
-                }
-              ],
-              "parent_name": null,
-              "declaration_names": [
-      
-              ],
-              "definition_path": null
-            },
-            {
-              "names": [
-                "admin"
-              ],
-              "traits": [
-                {
-                  "name": "with_email",
-                  "declaration_names": [
-      
-                  ],
-                  "definition_path": null
-                },
-                {
-                  "name": "combination",
-                  "declaration_names": [
-                    "with_email",
-                    "with_phone"
-                  ],
-                  "definition_path": null
-                }
-              ],
-              "parent_name": "user",
-              "declaration_names": [
-      
-              ],
-              "definition_path": "path/to/file:10"
-            }
-          ],
-          "traits": [
-            {
-              "name": "with_address",
-              "declaration_names": [
-      
-              ],
-              "definition_path": null
-            }
-          ]
-        },
-        "used": {
-          "factories": [
-      
-          ],
-          "traits": [
-      
-          ]
+        {
+          "defined": {
+            "factories": [
+              {
+                "names": [
+                  "user"
+                ],
+                "traits": [
+                  {
+                    "name": "with_phone",
+                    "declaration_names": [
+        
+                    ],
+                    "definition_path": null
+                  }
+                ],
+                "parent_name": null,
+                "declaration_names": [
+        
+                ],
+                "definition_path": null
+              },
+              {
+                "names": [
+                  "admin"
+                ],
+                "traits": [
+                  {
+                    "name": "with_email",
+                    "declaration_names": [
+        
+                    ],
+                    "definition_path": null
+                  },
+                  {
+                    "name": "combination",
+                    "declaration_names": [
+                      "with_email",
+                      "with_phone"
+                    ],
+                    "definition_path": null
+                  }
+                ],
+                "parent_name": "user",
+                "declaration_names": [
+        
+                ],
+                "definition_path": "path/to/file:10"
+              }
+            ],
+            "traits": [
+              {
+                "name": "with_address",
+                "declaration_names": [
+        
+                ],
+                "definition_path": null
+              }
+            ]
+          },
+          "used": {
+            "factories": [
+        
+            ],
+            "traits": [
+        
+            ]
+          }
         }
-      }
       TEXT
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "factory_trace"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,11 @@
-require 'bundler/setup'
-require 'factory_trace'
+require "bundler/setup"
+require "factory_trace"
 
-require 'tempfile'
+require "tempfile"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = '.rspec_status'
+  config.example_status_persistence_file_path = ".rspec_status"
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
Set up `RuboCop` based on the `Standard` rules + fix all `RuboCop` issues.

- Create a separate `rubocop.gemfile` and add it to Gemfile
- Add `rubocop` job to `CircleCI`

- Correct all layout issues
- Use `double-quoted` instead of `single`
- Avoid comma after the last item of a `hash` and an `array`
- Use `if` instead of empty `case` (_Do not use empty case condition, instead use an if expression_)
- Use `$stdout` instead of `STDOUT`
- Use safe navigation (`&.`) instead of checking if an object exists before calling the method
- Add frozen string literal comment
- Use `other` as a name instead of `collection`/`factory`/`trait`
- Remove unnecessary symbol conversion
- Use `caller_locations(2..2).first` instead of `caller_locations[1]`
- Move class methods inside a `class << self` block
- Check `block` argument explicitly instead of using `block_given?`
- Use `eval_gemfile` instead of `eval`


