### PR TITLE
[WIP] Add `enum` support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     description: The official CircleCI Ruby Docker image
     parameters:
       tag:
-        description: The circleci/ruby Docker image version tag
+        description: The cimg/ruby Docker image version tag
         type: string
         default: latest
     docker:
@@ -44,16 +44,15 @@ jobs:
           name: Install the gems specified by the Gemfile
           command: bundle install
       - run:
-          name: Run E2E
-          command: ruby spec/factory_trace/integration_tests/runner.rb
-      - run:
           name: Run RSpec
           command: |
             bundle exec rspec --profile 10 \
                               --format RspecJunitFormatter \
                               --out test_results/rspec.xml \
-                              --format progress \
-                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+                              --format progress
+      - run:
+          name: Run E2E
+          command: ruby spec/factory_trace/integration_tests/runner.rb
       - store_test_results:
           path: test_results
 

--- a/gemfiles/fb_4_10.gemfile
+++ b/gemfiles/fb_4_10.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "factory_bot", "~> 4.10.0"
+gem "activesupport", "< 7.0"
 
 gemspec path: "../"

--- a/lib/factory_trace.rb
+++ b/lib/factory_trace.rb
@@ -81,7 +81,7 @@ module FactoryTrace
     def trace_definitions!
       FactoryBot::Factory.prepend(FactoryTrace::MonkeyPatches::Factory)
       FactoryBot::Trait.prepend(FactoryTrace::MonkeyPatches::Trait)
-      FactoryBot::Enum.prepend(FactoryTrace::MonkeyPatches::Enum)
+      FactoryBot::Enum.prepend(FactoryTrace::MonkeyPatches::Enum) if FactoryBot::VERSION >= "6.0.0"
       FactoryBot::Syntax::Default::DSL.prepend(FactoryTrace::MonkeyPatches::Default::DSL)
       FactoryBot::DefinitionProxy.prepend(FactoryTrace::MonkeyPatches::DefinitionProxy)
     end

--- a/lib/factory_trace.rb
+++ b/lib/factory_trace.rb
@@ -30,6 +30,7 @@ require "factory_trace/writers/trace_writer"
 require "factory_trace/monkey_patches/monkey_patches"
 require "factory_trace/monkey_patches/factory"
 require "factory_trace/monkey_patches/trait"
+require "factory_trace/monkey_patches/enum"
 require "factory_trace/monkey_patches/definition_proxy"
 require "factory_trace/monkey_patches/dsl"
 
@@ -47,9 +48,6 @@ module FactoryTrace
 
     def stop
       return unless configuration.enabled
-
-      # This is required to exclude parent traits from +defined_traits+
-      FactoryBot.reload
 
       if configuration.mode?(:full)
         Writers::ReportWriter.new(configuration.out, configuration).write(Processors::FindUnused.call(defined, used))
@@ -83,6 +81,7 @@ module FactoryTrace
     def trace_definitions!
       FactoryBot::Factory.prepend(FactoryTrace::MonkeyPatches::Factory)
       FactoryBot::Trait.prepend(FactoryTrace::MonkeyPatches::Trait)
+      FactoryBot::Enum.prepend(FactoryTrace::MonkeyPatches::Enum)
       FactoryBot::Syntax::Default::DSL.prepend(FactoryTrace::MonkeyPatches::Default::DSL)
       FactoryBot::DefinitionProxy.prepend(FactoryTrace::MonkeyPatches::DefinitionProxy)
     end

--- a/lib/factory_trace/monkey_patches/definition_proxy.rb
+++ b/lib/factory_trace/monkey_patches/definition_proxy.rb
@@ -10,6 +10,10 @@ module FactoryTrace
       def trait(name, &block)
         @definition.define_trait(FactoryBot::Trait.new(name, Helpers::Caller.location, &block))
       end
+
+      def traits_for_enum(name, values = nil)
+        @definition.register_enum(FactoryBot::Enum.new(name, Helpers::Caller.location, values))
+      end
     end
   end
 end

--- a/lib/factory_trace/monkey_patches/enum.rb
+++ b/lib/factory_trace/monkey_patches/enum.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module FactoryTrace
+  module MonkeyPatches
+    module Enum
+      attr_reader :definition_path
+
+      def initialize(name, definition_path, values = nil)
+        @definition_path = definition_path
+        super(name, values)
+      end
+
+      private
+
+      def build_trait(trait_name, attribute_name, value)
+        ::FactoryBot::Trait.new(trait_name, definition_path) do
+          add_attribute(attribute_name) { value }
+        end
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,10 @@ class Comment
   attr_accessor :article
 end
 
+class Task
+  attr_accessor :status
+end
+
 FactoryBot.define do
   factory :user do
     name { "name" }
@@ -55,5 +59,9 @@ FactoryBot.define do
 
   trait :with_address do
     address { "address" }
+  end
+
+  factory :task do
+    traits_for_enum :status, {queued: 0, started: 1, finished: 2}
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -62,6 +62,6 @@ FactoryBot.define do
   end
 
   factory :task do
-    traits_for_enum :status, {queued: 0, started: 1, finished: 2}
+    FactoryBot::VERSION >= "6.0.0" ? traits_for_enum(:status, {queued: 0, started: 1, finished: 2}) : trait(:queued) { status { 0 } } && trait(:started) { status { 1 } } && trait(:finished) { status { 2 } }
   end
 end

--- a/spec/factory_trace/integration_tests/empty_spec.rb
+++ b/spec/factory_trace/integration_tests/empty_spec.rb
@@ -2,5 +2,6 @@
 
 RSpec.describe FactoryTrace do
   it "uses nothing" do
+    build(:task, :queued)
   end
 end

--- a/spec/factory_trace/integration_tests/expected.txt
+++ b/spec/factory_trace/integration_tests/expected.txt
@@ -1,14 +1,16 @@
-total number of unique used factories & traits: 0
-total number of unique unused factories & traits: 12
-unused factory user => spec/factories.rb:19
-unused trait with_phone of factory user => spec/factories.rb:22
-unused factory user_with_defaults => spec/factories.rb:26
-unused factory admin => spec/factories.rb:29
-unused trait with_email of factory admin => spec/factories.rb:30
-unused trait combination of factory admin => spec/factories.rb:34
-unused factory manager => spec/factories.rb:40
-unused factory company => spec/factories.rb:44
-unused trait with_manager of factory company => spec/factories.rb:45
-unused factory article, post => spec/factories.rb:50
-unused factory comment => spec/factories.rb:52
-unused global trait with_address => spec/factories.rb:56
+total number of unique used factories & traits: 2
+total number of unique unused factories & traits: 14
+unused factory user => spec/factories.rb:23
+unused trait with_phone of factory user => spec/factories.rb:26
+unused factory user_with_defaults => spec/factories.rb:30
+unused factory admin => spec/factories.rb:33
+unused trait with_email of factory admin => spec/factories.rb:34
+unused trait combination of factory admin => spec/factories.rb:38
+unused factory manager => spec/factories.rb:44
+unused factory company => spec/factories.rb:48
+unused trait with_manager of factory company => spec/factories.rb:49
+unused factory article, post => spec/factories.rb:54
+unused factory comment => spec/factories.rb:56
+unused trait started of factory task => spec/factories.rb:65
+unused trait finished of factory task => spec/factories.rb:65
+unused global trait with_address => spec/factories.rb:60

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -38,7 +38,11 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
           FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"]),
           FactoryTrace::Structures::Factory.new(
             ["task"],
-            []
+            [
+              FactoryTrace::Structures::Trait.new("queued"),
+              FactoryTrace::Structures::Trait.new("started"),
+              FactoryTrace::Structures::Trait.new("finished")
+            ]
           )
         ],
         [

--- a/spec/factory_trace/preprocessors/extract_defined_spec.rb
+++ b/spec/factory_trace/preprocessors/extract_defined_spec.rb
@@ -35,7 +35,11 @@ RSpec.describe FactoryTrace::Preprocessors::ExtractDefined do
             ]
           ),
           FactoryTrace::Structures::Factory.new(["article", "post"], []),
-          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"])
+          FactoryTrace::Structures::Factory.new(["comment"], [], declaration_names: ["post"]),
+          FactoryTrace::Structures::Factory.new(
+            ["task"],
+            []
+          )
         ],
         [
           FactoryTrace::Structures::Trait.new("with_address")

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 0},
-          {code: :unused, value: 13},
+          {code: :unused, value: 16},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -23,6 +23,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -34,7 +37,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 12},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -46,6 +49,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -57,7 +63,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 12},
+          {code: :unused, value: 15},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -69,6 +75,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -80,7 +89,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 11},
+          {code: :unused, value: 14},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -91,6 +100,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -102,7 +114,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 11},
+          {code: :unused, value: 14},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -113,6 +125,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -124,7 +139,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 11},
+          {code: :unused, value: 14},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -135,7 +150,10 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
-          {code: :unused, factory_names: ["task"]}
+          {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"}
         ])
       end
     end
@@ -146,7 +164,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 3},
-          {code: :unused, value: 10},
+          {code: :unused, value: 13},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -156,6 +174,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -170,13 +191,13 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           "comment" => Set.new,
           "manager" => Set.new,
           "user_with_defaults" => Set.new,
-          "task" => Set.new
+          "task" => Set.new(["queued", "started", "finished"])
         }
       end
 
       specify do
         expect(checker).to eq([
-          {code: :used, value: 13},
+          {code: :used, value: 16},
           {code: :unused, value: 0}
         ])
       end
@@ -188,7 +209,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 5},
-          {code: :unused, value: 8},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["manager"]},
           {code: :unused, factory_names: ["company"]},
@@ -196,6 +217,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -207,7 +231,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 9},
+          {code: :unused, value: 12},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -216,6 +240,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -227,7 +254,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 11},
+          {code: :unused, value: 14},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -238,6 +265,9 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -249,13 +279,16 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 6},
-          {code: :unused, value: 7},
+          {code: :unused, value: 10},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
           {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -267,7 +300,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 9},
+          {code: :unused, value: 12},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -276,7 +309,10 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
-          {code: :unused, factory_names: ["task"]}
+          {code: :unused, factory_names: ["task"]},
+          {code: :unused, factory_names: ["task"], trait_name: "queued"},
+          {code: :unused, factory_names: ["task"], trait_name: "started"},
+          {code: :unused, factory_names: ["task"], trait_name: "finished"}
         ])
       end
     end

--- a/spec/factory_trace/processors/find_unused_spec.rb
+++ b/spec/factory_trace/processors/find_unused_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 0},
-          {code: :unused, value: 12},
+          {code: :unused, value: 13},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -22,6 +22,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -33,7 +34,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 11},
+          {code: :unused, value: 12},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -44,6 +45,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -55,7 +57,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 1},
-          {code: :unused, value: 11},
+          {code: :unused, value: 12},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -66,6 +68,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -77,7 +80,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -87,6 +90,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -98,7 +102,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
@@ -108,6 +112,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -119,7 +124,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"]},
@@ -129,7 +134,8 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
-          {code: :unused, factory_names: ["comment"]}
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]}
         ])
       end
     end
@@ -140,7 +146,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 3},
-          {code: :unused, value: 9},
+          {code: :unused, value: 10},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -149,17 +155,28 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
     end
 
     context "when everything were used" do
-      let(:data) { {"admin" => Set.new(["with_phone", "with_email", "combination"]), "company" => Set.new(["with_address", "with_manager"]), "article" => Set.new, "comment" => Set.new, "manager" => Set.new, "user_with_defaults" => Set.new} }
+      let(:data) do
+        {
+          "admin" => Set.new(["with_phone", "with_email", "combination"]),
+          "company" => Set.new(["with_address", "with_manager"]),
+          "article" => Set.new,
+          "comment" => Set.new,
+          "manager" => Set.new,
+          "user_with_defaults" => Set.new,
+          "task" => Set.new
+        }
+      end
 
       specify do
         expect(checker).to eq([
-          {code: :used, value: 12},
+          {code: :used, value: 13},
           {code: :unused, value: 0}
         ])
       end
@@ -171,13 +188,14 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 5},
-          {code: :unused, value: 7},
+          {code: :unused, value: 8},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["manager"]},
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -189,7 +207,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 8},
+          {code: :unused, value: 9},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -197,6 +215,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -208,7 +227,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 2},
-          {code: :unused, value: 10},
+          {code: :unused, value: 11},
           {code: :unused, factory_names: ["user"]},
           {code: :unused, factory_names: ["user"], trait_name: "with_phone"},
           {code: :unused, factory_names: ["user_with_defaults"]},
@@ -218,6 +237,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["manager"]},
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -229,12 +249,13 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 6},
-          {code: :unused, value: 6},
+          {code: :unused, value: 7},
           {code: :unused, factory_names: ["user_with_defaults"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
           {code: :unused, factory_names: ["article", "post"]},
           {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]},
           {code: :unused, trait_name: "with_address"}
         ])
       end
@@ -246,7 +267,7 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
       specify do
         expect(checker).to eq([
           {code: :used, value: 4},
-          {code: :unused, value: 8},
+          {code: :unused, value: 9},
           {code: :unused, factory_names: ["admin"]},
           {code: :unused, factory_names: ["admin"], trait_name: "with_email"},
           {code: :unused, factory_names: ["admin"], trait_name: "combination"},
@@ -254,7 +275,8 @@ RSpec.describe FactoryTrace::Processors::FindUnused do
           {code: :unused, factory_names: ["company"]},
           {code: :unused, factory_names: ["company"], trait_name: "with_manager"},
           {code: :unused, factory_names: ["article", "post"]},
-          {code: :unused, factory_names: ["comment"]}
+          {code: :unused, factory_names: ["comment"]},
+          {code: :unused, factory_names: ["task"]}
         ])
       end
     end


### PR DESCRIPTION
```sh
FB_TRACE_FILE=integration-test-results.txt bundle exec rspec spec/factory_trace/integration_tests/empty_spec.rb
```

```ruby
An error occurred in an `after(:suite)` hook.
Failure/Error: return if trait.has_prioritized_status?(status)

NoMethodError:
  undefined method `has_prioritized_status?' for nil:NilClass
# ./lib/factory_trace/processors/find_unused.rb:90:in `mark_trait'
# ./lib/factory_trace/processors/find_unused.rb:47:in `block (2 levels) in mark_as_used'
# ./lib/factory_trace/processors/find_unused.rb:45:in `each'
# ./lib/factory_trace/processors/find_unused.rb:45:in `block in mark_as_used'
# ./lib/factory_trace/processors/find_unused.rb:41:in `each'
# ./lib/factory_trace/processors/find_unused.rb:41:in `mark_as_used'
# ./lib/factory_trace/processors/find_unused.rb:14:in `call'
# ./lib/factory_trace.rb:56:in `stop'
# ./lib/integrations/rspec.rb:5:in `block (2 levels) in <top (required)>'
```



```ruby
FactoryTrace
  uses nothing (FAILED - 1)

Failures:

  1) FactoryTrace uses nothing
     Failure/Error:
       def initialize(name, definition_path, &block)
         @definition_path = definition_path
         super(name, &block)
       end

     ArgumentError:
       wrong number of arguments (given 1, expected 2)
     # ./lib/factory_trace/monkey_patches/trait.rb:8:in `initialize'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:22:in `new'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:22:in `build_trait'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:11:in `block in build_traits'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:10:in `each'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:10:in `map'
     # gems/factory_bot-6.2.0/lib/factory_bot/enum.rb:10:in `build_traits'
     # gems/factory_bot-6.2.0/lib/factory_bot/definition.rb:168:in `block in expand_enum_traits'
     # gems/factory_bot-6.2.0/lib/factory_bot/definition.rb:167:in `each'
     # gems/factory_bot-6.2.0/lib/factory_bot/definition.rb:167:in `expand_enum_traits'
     # gems/factory_bot-6.2.0/lib/factory_bot/definition.rb:50:in `compile'
     # gems/factory_bot-6.2.0/lib/factory_bot/factory.rb:87:in `compile'
     # gems/factory_bot-6.2.0/lib/factory_bot/factory_runner.rb:14:in `run'
     # gems/factory_bot-6.2.0/lib/factory_bot/strategy_syntax_method_registrar.rb:28:in `block in define_singular_strategy_method'
     # ./spec/factory_trace/integration_tests/empty_spec.rb:5:in `block (2 levels) in <top (required)>'
```