### PR TITLE
Update to use the current CircleCI docker image family and add Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ executors:
     description: The official CircleCI Ruby Docker image
     parameters:
       tag:
-        description: The circleci/ruby Docker image version tag
+        description: The cimg/ruby Docker image version tag
         type: string
-        default: latest
+        default: "3.1"
     docker:
-      - image: circleci/ruby:<< parameters.tag >>
+      - image: cimg/ruby:<< parameters.tag >>
     environment:
       - BUNDLE_JOBS: 4
       - BUNDLE_RETRY: 3
@@ -89,7 +89,7 @@ workflows:
                 "2.6",
                 "2.7",
                 "3.0",
-                "latest"
+                "3.1"
               ]
               gemfile: [
                 "gemfiles/fb_4_10.gemfile",


### PR DESCRIPTION
As described [here](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034), the `circleci` prefixed images are deprecated and, as of the end of 2021, images are no longer being updated/created.

To add 3.1 to the CI pipeline, it's necessary to upgrade to the current `cimg` family.  This PR does that update, and explicitly adds Ruby 3.1 to the CI matrix.