### PR TITLE
support/ruby-version-until-3.2-and-adding-FactoryBot-6.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,15 @@ jobs:
         ruby-version:
           - '2.6'
           - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
           - 'head'
         gemfile:
           - 'gemfiles/fb_4_11.gemfile'
           - 'gemfiles/fb_5_2.gemfile'
           - 'gemfiles/fb_6_2.gemfile'
+          - 'gemfiles/fb_6_4.gemfile'
 
     steps:
       - uses: actions/checkout@v3

--- a/gemfiles/fb_6_4.gemfile
+++ b/gemfiles/fb_6_4.gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "factory_bot", "~> 6.4.0"
+
+gemspec path: "../"


### PR DESCRIPTION
#### Description

Adding support for more Ruby versions (3.0, 3.1, 3.2) and adding FactoryBot 6.4 for testing